### PR TITLE
Styled icons theme fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+**Steps to contribute icons to grommet-icons**
+
+1) Fork the grommet-icons project and and clone.
+2) Add your raw svg files in this [folder](https://github.com/grommet/grommet-icons/tree/master/public/img) (use the other raw svgs as a reference on how to structure your file content and naming conventions).
+3) Run `npm run generate-icons` to generate the react components from the raw svg files.
+4) Consider adding search metadata to this [file](https://github.com/grommet/grommet-icons/blob/master/src/js/metadata.js) to help finding your new icon.
+5) Run `npm run test-update` to recreate the test snapshot files.
+6) Run `npm run check` to make sure everything is passing (including js linting).
+7) Share with the community by submitting a PR.

--- a/src/js/StyledIcon.js
+++ b/src/js/StyledIcon.js
@@ -34,7 +34,6 @@ const StyledIcon = styled.svg`
     *[stroke*="#"],
     *[STROKE*="#"] {
       stroke: inherit;
-      fill: none;
     }
 
     *[fill-rule],
@@ -42,7 +41,6 @@ const StyledIcon = styled.svg`
     *[fill*="#"],
     *[FILL*="#"] {
       fill: inherit;
-      stroke: none;
     }
   `}
 `;

--- a/src/js/__tests__/__snapshots__/Icon-test.js.snap
+++ b/src/js/__tests__/__snapshots__/Icon-test.js.snap
@@ -22,7 +22,6 @@ exports[`Icon renders 1`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -30,7 +29,6 @@ exports[`Icon renders 1`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -81,7 +79,6 @@ exports[`Icon renders all icons 1`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -89,7 +86,6 @@ exports[`Icon renders all icons 1`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -134,7 +130,6 @@ exports[`Icon renders all icons 2`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -142,7 +137,6 @@ exports[`Icon renders all icons 2`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -185,7 +179,6 @@ exports[`Icon renders all icons 3`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -193,7 +186,6 @@ exports[`Icon renders all icons 3`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -236,7 +228,6 @@ exports[`Icon renders all icons 4`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -244,7 +235,6 @@ exports[`Icon renders all icons 4`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -287,7 +277,6 @@ exports[`Icon renders all icons 5`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -295,7 +284,6 @@ exports[`Icon renders all icons 5`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -340,7 +328,6 @@ exports[`Icon renders all icons 6`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -348,7 +335,6 @@ exports[`Icon renders all icons 6`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -391,7 +377,6 @@ exports[`Icon renders all icons 7`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -399,7 +384,6 @@ exports[`Icon renders all icons 7`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -442,7 +426,6 @@ exports[`Icon renders all icons 8`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -450,7 +433,6 @@ exports[`Icon renders all icons 8`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -493,7 +475,6 @@ exports[`Icon renders all icons 9`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -501,7 +482,6 @@ exports[`Icon renders all icons 9`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -545,7 +525,6 @@ exports[`Icon renders all icons 10`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -553,7 +532,6 @@ exports[`Icon renders all icons 10`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -596,7 +574,6 @@ exports[`Icon renders all icons 11`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -604,7 +581,6 @@ exports[`Icon renders all icons 11`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -647,7 +623,6 @@ exports[`Icon renders all icons 12`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -655,7 +630,6 @@ exports[`Icon renders all icons 12`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -698,7 +672,6 @@ exports[`Icon renders all icons 13`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -706,7 +679,6 @@ exports[`Icon renders all icons 13`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -749,7 +721,6 @@ exports[`Icon renders all icons 14`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -757,7 +728,6 @@ exports[`Icon renders all icons 14`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -799,7 +769,6 @@ exports[`Icon renders all icons 15`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -807,7 +776,6 @@ exports[`Icon renders all icons 15`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -849,7 +817,6 @@ exports[`Icon renders all icons 16`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -857,7 +824,6 @@ exports[`Icon renders all icons 16`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -900,7 +866,6 @@ exports[`Icon renders all icons 17`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -908,7 +873,6 @@ exports[`Icon renders all icons 17`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -950,7 +914,6 @@ exports[`Icon renders all icons 18`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -958,7 +921,6 @@ exports[`Icon renders all icons 18`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -1001,7 +963,6 @@ exports[`Icon renders all icons 19`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -1009,7 +970,6 @@ exports[`Icon renders all icons 19`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -1051,7 +1011,6 @@ exports[`Icon renders all icons 20`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -1059,7 +1018,6 @@ exports[`Icon renders all icons 20`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -1102,7 +1060,6 @@ exports[`Icon renders all icons 21`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -1110,7 +1067,6 @@ exports[`Icon renders all icons 21`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -1153,7 +1109,6 @@ exports[`Icon renders all icons 22`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -1161,7 +1116,6 @@ exports[`Icon renders all icons 22`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -1203,7 +1157,6 @@ exports[`Icon renders all icons 23`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -1211,7 +1164,6 @@ exports[`Icon renders all icons 23`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -1254,7 +1206,6 @@ exports[`Icon renders all icons 24`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -1262,7 +1213,6 @@ exports[`Icon renders all icons 24`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -1304,7 +1254,6 @@ exports[`Icon renders all icons 25`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -1312,7 +1261,6 @@ exports[`Icon renders all icons 25`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -1355,7 +1303,6 @@ exports[`Icon renders all icons 26`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -1363,7 +1310,6 @@ exports[`Icon renders all icons 26`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -1408,7 +1354,6 @@ exports[`Icon renders all icons 27`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -1416,7 +1361,6 @@ exports[`Icon renders all icons 27`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -1459,7 +1403,6 @@ exports[`Icon renders all icons 28`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -1467,7 +1410,6 @@ exports[`Icon renders all icons 28`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -1510,7 +1452,6 @@ exports[`Icon renders all icons 29`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -1518,7 +1459,6 @@ exports[`Icon renders all icons 29`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -1561,7 +1501,6 @@ exports[`Icon renders all icons 30`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -1569,7 +1508,6 @@ exports[`Icon renders all icons 30`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -1614,7 +1552,6 @@ exports[`Icon renders all icons 31`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -1622,7 +1559,6 @@ exports[`Icon renders all icons 31`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -1665,7 +1601,6 @@ exports[`Icon renders all icons 32`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -1673,7 +1608,6 @@ exports[`Icon renders all icons 32`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -1716,7 +1650,6 @@ exports[`Icon renders all icons 33`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -1724,7 +1657,6 @@ exports[`Icon renders all icons 33`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -1767,7 +1699,6 @@ exports[`Icon renders all icons 34`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -1775,7 +1706,6 @@ exports[`Icon renders all icons 34`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -1818,7 +1748,6 @@ exports[`Icon renders all icons 35`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -1826,7 +1755,6 @@ exports[`Icon renders all icons 35`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -1869,7 +1797,6 @@ exports[`Icon renders all icons 36`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -1877,7 +1804,6 @@ exports[`Icon renders all icons 36`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -1919,7 +1845,6 @@ exports[`Icon renders all icons 37`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -1927,7 +1852,6 @@ exports[`Icon renders all icons 37`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -1970,7 +1894,6 @@ exports[`Icon renders all icons 38`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -1978,7 +1901,6 @@ exports[`Icon renders all icons 38`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -2021,7 +1943,6 @@ exports[`Icon renders all icons 39`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -2029,7 +1950,6 @@ exports[`Icon renders all icons 39`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -2069,7 +1989,6 @@ exports[`Icon renders all icons 40`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -2077,7 +1996,6 @@ exports[`Icon renders all icons 40`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -2120,7 +2038,6 @@ exports[`Icon renders all icons 41`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -2128,7 +2045,6 @@ exports[`Icon renders all icons 41`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -2171,7 +2087,6 @@ exports[`Icon renders all icons 42`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -2179,7 +2094,6 @@ exports[`Icon renders all icons 42`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -2222,7 +2136,6 @@ exports[`Icon renders all icons 43`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -2230,7 +2143,6 @@ exports[`Icon renders all icons 43`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -2277,7 +2189,6 @@ exports[`Icon renders all icons 44`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -2285,7 +2196,6 @@ exports[`Icon renders all icons 44`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -2328,7 +2238,6 @@ exports[`Icon renders all icons 45`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -2336,7 +2245,6 @@ exports[`Icon renders all icons 45`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -2380,7 +2288,6 @@ exports[`Icon renders all icons 46`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -2388,7 +2295,6 @@ exports[`Icon renders all icons 46`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -2431,7 +2337,6 @@ exports[`Icon renders all icons 47`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -2439,7 +2344,6 @@ exports[`Icon renders all icons 47`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -2482,7 +2386,6 @@ exports[`Icon renders all icons 48`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -2490,7 +2393,6 @@ exports[`Icon renders all icons 48`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -2533,7 +2435,6 @@ exports[`Icon renders all icons 49`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -2541,7 +2442,6 @@ exports[`Icon renders all icons 49`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -2584,7 +2484,6 @@ exports[`Icon renders all icons 50`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -2592,7 +2491,6 @@ exports[`Icon renders all icons 50`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -2635,7 +2533,6 @@ exports[`Icon renders all icons 51`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -2643,7 +2540,6 @@ exports[`Icon renders all icons 51`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -2686,7 +2582,6 @@ exports[`Icon renders all icons 52`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -2694,7 +2589,6 @@ exports[`Icon renders all icons 52`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -2737,7 +2631,6 @@ exports[`Icon renders all icons 53`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -2745,7 +2638,6 @@ exports[`Icon renders all icons 53`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -2788,7 +2680,6 @@ exports[`Icon renders all icons 54`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -2796,7 +2687,6 @@ exports[`Icon renders all icons 54`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -2840,7 +2730,6 @@ exports[`Icon renders all icons 55`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -2848,7 +2737,6 @@ exports[`Icon renders all icons 55`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -2891,7 +2779,6 @@ exports[`Icon renders all icons 56`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -2899,7 +2786,6 @@ exports[`Icon renders all icons 56`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -2942,7 +2828,6 @@ exports[`Icon renders all icons 57`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -2950,7 +2835,6 @@ exports[`Icon renders all icons 57`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -2993,7 +2877,6 @@ exports[`Icon renders all icons 58`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -3001,7 +2884,6 @@ exports[`Icon renders all icons 58`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -3045,7 +2927,6 @@ exports[`Icon renders all icons 59`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -3053,7 +2934,6 @@ exports[`Icon renders all icons 59`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -3097,7 +2977,6 @@ exports[`Icon renders all icons 60`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -3105,7 +2984,6 @@ exports[`Icon renders all icons 60`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -3148,7 +3026,6 @@ exports[`Icon renders all icons 61`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -3156,7 +3033,6 @@ exports[`Icon renders all icons 61`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -3199,7 +3075,6 @@ exports[`Icon renders all icons 62`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -3207,7 +3082,6 @@ exports[`Icon renders all icons 62`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -3250,7 +3124,6 @@ exports[`Icon renders all icons 63`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -3258,7 +3131,6 @@ exports[`Icon renders all icons 63`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -3300,7 +3172,6 @@ exports[`Icon renders all icons 64`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -3308,7 +3179,6 @@ exports[`Icon renders all icons 64`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -3351,7 +3221,6 @@ exports[`Icon renders all icons 65`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -3359,7 +3228,6 @@ exports[`Icon renders all icons 65`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -3402,7 +3270,6 @@ exports[`Icon renders all icons 66`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -3410,7 +3277,6 @@ exports[`Icon renders all icons 66`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -3453,7 +3319,6 @@ exports[`Icon renders all icons 67`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -3461,7 +3326,6 @@ exports[`Icon renders all icons 67`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -3504,7 +3368,6 @@ exports[`Icon renders all icons 68`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -3512,7 +3375,6 @@ exports[`Icon renders all icons 68`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -3555,7 +3417,6 @@ exports[`Icon renders all icons 69`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -3563,7 +3424,6 @@ exports[`Icon renders all icons 69`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -3606,7 +3466,6 @@ exports[`Icon renders all icons 70`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -3614,7 +3473,6 @@ exports[`Icon renders all icons 70`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -3657,7 +3515,6 @@ exports[`Icon renders all icons 71`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -3665,7 +3522,6 @@ exports[`Icon renders all icons 71`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -3711,7 +3567,6 @@ exports[`Icon renders all icons 72`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -3719,7 +3574,6 @@ exports[`Icon renders all icons 72`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -3762,7 +3616,6 @@ exports[`Icon renders all icons 73`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -3770,7 +3623,6 @@ exports[`Icon renders all icons 73`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -3828,7 +3680,6 @@ exports[`Icon renders all icons 74`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -3836,7 +3687,6 @@ exports[`Icon renders all icons 74`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -3879,7 +3729,6 @@ exports[`Icon renders all icons 75`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -3887,7 +3736,6 @@ exports[`Icon renders all icons 75`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -3930,7 +3778,6 @@ exports[`Icon renders all icons 76`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -3938,7 +3785,6 @@ exports[`Icon renders all icons 76`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -3981,7 +3827,6 @@ exports[`Icon renders all icons 77`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -3989,7 +3834,6 @@ exports[`Icon renders all icons 77`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -4032,7 +3876,6 @@ exports[`Icon renders all icons 78`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -4040,7 +3883,6 @@ exports[`Icon renders all icons 78`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -4083,7 +3925,6 @@ exports[`Icon renders all icons 79`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -4091,7 +3932,6 @@ exports[`Icon renders all icons 79`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -4134,7 +3974,6 @@ exports[`Icon renders all icons 80`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -4142,7 +3981,6 @@ exports[`Icon renders all icons 80`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -4185,7 +4023,6 @@ exports[`Icon renders all icons 81`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -4193,7 +4030,6 @@ exports[`Icon renders all icons 81`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -4236,7 +4072,6 @@ exports[`Icon renders all icons 82`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -4244,7 +4079,6 @@ exports[`Icon renders all icons 82`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -4287,7 +4121,6 @@ exports[`Icon renders all icons 83`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -4295,7 +4128,6 @@ exports[`Icon renders all icons 83`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -4338,7 +4170,6 @@ exports[`Icon renders all icons 84`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -4346,7 +4177,6 @@ exports[`Icon renders all icons 84`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -4389,7 +4219,6 @@ exports[`Icon renders all icons 85`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -4397,7 +4226,6 @@ exports[`Icon renders all icons 85`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -4440,7 +4268,6 @@ exports[`Icon renders all icons 86`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -4448,7 +4275,6 @@ exports[`Icon renders all icons 86`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -4491,7 +4317,6 @@ exports[`Icon renders all icons 87`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -4499,7 +4324,6 @@ exports[`Icon renders all icons 87`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -4542,7 +4366,6 @@ exports[`Icon renders all icons 88`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -4550,7 +4373,6 @@ exports[`Icon renders all icons 88`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -4593,7 +4415,6 @@ exports[`Icon renders all icons 89`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -4601,7 +4422,6 @@ exports[`Icon renders all icons 89`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -4644,7 +4464,6 @@ exports[`Icon renders all icons 90`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -4652,7 +4471,6 @@ exports[`Icon renders all icons 90`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -4694,7 +4512,6 @@ exports[`Icon renders all icons 91`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -4702,7 +4519,6 @@ exports[`Icon renders all icons 91`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -4745,7 +4561,6 @@ exports[`Icon renders all icons 92`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -4753,7 +4568,6 @@ exports[`Icon renders all icons 92`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -4798,7 +4612,6 @@ exports[`Icon renders all icons 93`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -4806,7 +4619,6 @@ exports[`Icon renders all icons 93`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -4849,7 +4661,6 @@ exports[`Icon renders all icons 94`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -4857,7 +4668,6 @@ exports[`Icon renders all icons 94`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -4899,7 +4709,6 @@ exports[`Icon renders all icons 95`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -4907,7 +4716,6 @@ exports[`Icon renders all icons 95`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -4950,7 +4758,6 @@ exports[`Icon renders all icons 96`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -4958,7 +4765,6 @@ exports[`Icon renders all icons 96`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -5001,7 +4807,6 @@ exports[`Icon renders all icons 97`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -5009,7 +4814,6 @@ exports[`Icon renders all icons 97`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -5052,7 +4856,6 @@ exports[`Icon renders all icons 98`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -5060,7 +4863,6 @@ exports[`Icon renders all icons 98`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -5103,7 +4905,6 @@ exports[`Icon renders all icons 99`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -5111,7 +4912,6 @@ exports[`Icon renders all icons 99`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -5154,7 +4954,6 @@ exports[`Icon renders all icons 100`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -5162,7 +4961,6 @@ exports[`Icon renders all icons 100`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -5205,7 +5003,6 @@ exports[`Icon renders all icons 101`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -5213,7 +5010,6 @@ exports[`Icon renders all icons 101`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -5258,7 +5054,6 @@ exports[`Icon renders all icons 102`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -5266,7 +5061,6 @@ exports[`Icon renders all icons 102`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -5309,7 +5103,6 @@ exports[`Icon renders all icons 103`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -5317,7 +5110,6 @@ exports[`Icon renders all icons 103`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -5360,7 +5152,6 @@ exports[`Icon renders all icons 104`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -5368,7 +5159,6 @@ exports[`Icon renders all icons 104`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -5411,7 +5201,6 @@ exports[`Icon renders all icons 105`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -5419,7 +5208,6 @@ exports[`Icon renders all icons 105`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -5462,7 +5250,6 @@ exports[`Icon renders all icons 106`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -5470,7 +5257,6 @@ exports[`Icon renders all icons 106`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -5512,7 +5298,6 @@ exports[`Icon renders all icons 107`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -5520,7 +5305,6 @@ exports[`Icon renders all icons 107`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -5563,7 +5347,6 @@ exports[`Icon renders all icons 108`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -5571,7 +5354,6 @@ exports[`Icon renders all icons 108`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -5616,7 +5398,6 @@ exports[`Icon renders all icons 109`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -5624,7 +5405,6 @@ exports[`Icon renders all icons 109`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -5667,7 +5447,6 @@ exports[`Icon renders all icons 110`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -5675,7 +5454,6 @@ exports[`Icon renders all icons 110`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -5718,7 +5496,6 @@ exports[`Icon renders all icons 111`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -5726,7 +5503,6 @@ exports[`Icon renders all icons 111`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -5769,7 +5545,6 @@ exports[`Icon renders all icons 112`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -5777,7 +5552,6 @@ exports[`Icon renders all icons 112`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -5820,7 +5594,6 @@ exports[`Icon renders all icons 113`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -5828,7 +5601,6 @@ exports[`Icon renders all icons 113`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -5871,7 +5643,6 @@ exports[`Icon renders all icons 114`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -5879,7 +5650,6 @@ exports[`Icon renders all icons 114`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -5922,7 +5692,6 @@ exports[`Icon renders all icons 115`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -5930,7 +5699,6 @@ exports[`Icon renders all icons 115`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -5973,7 +5741,6 @@ exports[`Icon renders all icons 116`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -5981,7 +5748,6 @@ exports[`Icon renders all icons 116`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -6024,7 +5790,6 @@ exports[`Icon renders all icons 117`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -6032,7 +5797,6 @@ exports[`Icon renders all icons 117`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -6074,7 +5838,6 @@ exports[`Icon renders all icons 118`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -6082,7 +5845,6 @@ exports[`Icon renders all icons 118`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -6125,7 +5887,6 @@ exports[`Icon renders all icons 119`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -6133,7 +5894,6 @@ exports[`Icon renders all icons 119`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -6176,7 +5936,6 @@ exports[`Icon renders all icons 120`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -6184,7 +5943,6 @@ exports[`Icon renders all icons 120`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -6228,7 +5986,6 @@ exports[`Icon renders all icons 121`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -6236,7 +5993,6 @@ exports[`Icon renders all icons 121`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -6279,7 +6035,6 @@ exports[`Icon renders all icons 122`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -6287,7 +6042,6 @@ exports[`Icon renders all icons 122`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -6330,7 +6084,6 @@ exports[`Icon renders all icons 123`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -6338,7 +6091,6 @@ exports[`Icon renders all icons 123`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -6383,7 +6135,6 @@ exports[`Icon renders all icons 124`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -6391,7 +6142,6 @@ exports[`Icon renders all icons 124`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -6434,7 +6184,6 @@ exports[`Icon renders all icons 125`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -6442,7 +6191,6 @@ exports[`Icon renders all icons 125`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -6485,7 +6233,6 @@ exports[`Icon renders all icons 126`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -6493,7 +6240,6 @@ exports[`Icon renders all icons 126`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -6537,7 +6283,6 @@ exports[`Icon renders all icons 127`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -6545,7 +6290,6 @@ exports[`Icon renders all icons 127`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -6587,7 +6331,6 @@ exports[`Icon renders all icons 128`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -6595,7 +6338,6 @@ exports[`Icon renders all icons 128`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -6638,7 +6380,6 @@ exports[`Icon renders all icons 129`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -6646,7 +6387,6 @@ exports[`Icon renders all icons 129`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -6689,7 +6429,6 @@ exports[`Icon renders all icons 130`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -6697,7 +6436,6 @@ exports[`Icon renders all icons 130`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -6740,7 +6478,6 @@ exports[`Icon renders all icons 131`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -6748,7 +6485,6 @@ exports[`Icon renders all icons 131`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -6791,7 +6527,6 @@ exports[`Icon renders all icons 132`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -6799,7 +6534,6 @@ exports[`Icon renders all icons 132`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -6842,7 +6576,6 @@ exports[`Icon renders all icons 133`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -6850,7 +6583,6 @@ exports[`Icon renders all icons 133`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -6893,7 +6625,6 @@ exports[`Icon renders all icons 134`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -6901,7 +6632,6 @@ exports[`Icon renders all icons 134`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -6944,7 +6674,6 @@ exports[`Icon renders all icons 135`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -6952,7 +6681,6 @@ exports[`Icon renders all icons 135`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -6995,7 +6723,6 @@ exports[`Icon renders all icons 136`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -7003,7 +6730,6 @@ exports[`Icon renders all icons 136`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -7046,7 +6772,6 @@ exports[`Icon renders all icons 137`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -7054,7 +6779,6 @@ exports[`Icon renders all icons 137`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -7097,7 +6821,6 @@ exports[`Icon renders all icons 138`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -7105,7 +6828,6 @@ exports[`Icon renders all icons 138`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -7148,7 +6870,6 @@ exports[`Icon renders all icons 139`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -7156,7 +6877,6 @@ exports[`Icon renders all icons 139`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -7199,7 +6919,6 @@ exports[`Icon renders all icons 140`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -7207,7 +6926,6 @@ exports[`Icon renders all icons 140`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -7250,7 +6968,6 @@ exports[`Icon renders all icons 141`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -7258,7 +6975,6 @@ exports[`Icon renders all icons 141`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -7301,7 +7017,6 @@ exports[`Icon renders all icons 142`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -7309,7 +7024,6 @@ exports[`Icon renders all icons 142`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -7352,7 +7066,6 @@ exports[`Icon renders all icons 143`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -7360,7 +7073,6 @@ exports[`Icon renders all icons 143`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -7403,7 +7115,6 @@ exports[`Icon renders all icons 144`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -7411,7 +7122,6 @@ exports[`Icon renders all icons 144`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -7454,7 +7164,6 @@ exports[`Icon renders all icons 145`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -7462,7 +7171,6 @@ exports[`Icon renders all icons 145`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -7505,7 +7213,6 @@ exports[`Icon renders all icons 146`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -7513,7 +7220,6 @@ exports[`Icon renders all icons 146`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -7556,7 +7262,6 @@ exports[`Icon renders all icons 147`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -7564,7 +7269,6 @@ exports[`Icon renders all icons 147`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -7607,7 +7311,6 @@ exports[`Icon renders all icons 148`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -7615,7 +7318,6 @@ exports[`Icon renders all icons 148`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -7658,7 +7360,6 @@ exports[`Icon renders all icons 149`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -7666,7 +7367,6 @@ exports[`Icon renders all icons 149`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -7709,7 +7409,6 @@ exports[`Icon renders all icons 150`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -7717,7 +7416,6 @@ exports[`Icon renders all icons 150`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -7760,7 +7458,6 @@ exports[`Icon renders all icons 151`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -7768,7 +7465,6 @@ exports[`Icon renders all icons 151`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -7811,7 +7507,6 @@ exports[`Icon renders all icons 152`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -7819,7 +7514,6 @@ exports[`Icon renders all icons 152`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -7862,7 +7556,6 @@ exports[`Icon renders all icons 153`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -7870,7 +7563,6 @@ exports[`Icon renders all icons 153`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -7913,7 +7605,6 @@ exports[`Icon renders all icons 154`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -7921,7 +7612,6 @@ exports[`Icon renders all icons 154`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -7964,7 +7654,6 @@ exports[`Icon renders all icons 155`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -7972,7 +7661,6 @@ exports[`Icon renders all icons 155`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -8015,7 +7703,6 @@ exports[`Icon renders all icons 156`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -8023,7 +7710,6 @@ exports[`Icon renders all icons 156`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -8066,7 +7752,6 @@ exports[`Icon renders all icons 157`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -8074,7 +7759,6 @@ exports[`Icon renders all icons 157`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -8117,7 +7801,6 @@ exports[`Icon renders all icons 158`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -8125,7 +7808,6 @@ exports[`Icon renders all icons 158`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -8168,7 +7850,6 @@ exports[`Icon renders all icons 159`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -8176,7 +7857,6 @@ exports[`Icon renders all icons 159`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -8219,7 +7899,6 @@ exports[`Icon renders all icons 160`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -8227,7 +7906,6 @@ exports[`Icon renders all icons 160`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -8269,7 +7947,6 @@ exports[`Icon renders all icons 161`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -8277,7 +7954,6 @@ exports[`Icon renders all icons 161`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -8321,7 +7997,6 @@ exports[`Icon renders all icons 162`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -8329,7 +8004,6 @@ exports[`Icon renders all icons 162`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -8372,7 +8046,6 @@ exports[`Icon renders all icons 163`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -8380,7 +8053,6 @@ exports[`Icon renders all icons 163`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -8423,7 +8095,6 @@ exports[`Icon renders all icons 164`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -8431,7 +8102,6 @@ exports[`Icon renders all icons 164`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -8474,7 +8144,6 @@ exports[`Icon renders all icons 165`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -8482,7 +8151,6 @@ exports[`Icon renders all icons 165`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -8525,7 +8193,6 @@ exports[`Icon renders all icons 166`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -8533,7 +8200,6 @@ exports[`Icon renders all icons 166`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -8575,7 +8241,6 @@ exports[`Icon renders all icons 167`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -8583,7 +8248,6 @@ exports[`Icon renders all icons 167`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -8626,7 +8290,6 @@ exports[`Icon renders all icons 168`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -8634,7 +8297,6 @@ exports[`Icon renders all icons 168`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -8675,7 +8337,6 @@ exports[`Icon renders all icons 169`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -8683,7 +8344,6 @@ exports[`Icon renders all icons 169`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -8725,7 +8385,6 @@ exports[`Icon renders all icons 170`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -8733,7 +8392,6 @@ exports[`Icon renders all icons 170`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -8776,7 +8434,6 @@ exports[`Icon renders all icons 171`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -8784,7 +8441,6 @@ exports[`Icon renders all icons 171`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -8827,7 +8483,6 @@ exports[`Icon renders all icons 172`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -8835,7 +8490,6 @@ exports[`Icon renders all icons 172`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -8879,7 +8533,6 @@ exports[`Icon renders all icons 173`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -8887,7 +8540,6 @@ exports[`Icon renders all icons 173`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -8928,7 +8580,6 @@ exports[`Icon renders all icons 174`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -8936,7 +8587,6 @@ exports[`Icon renders all icons 174`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -8985,7 +8635,6 @@ exports[`Icon renders all icons 175`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -8993,7 +8642,6 @@ exports[`Icon renders all icons 175`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -9036,7 +8684,6 @@ exports[`Icon renders all icons 176`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -9044,7 +8691,6 @@ exports[`Icon renders all icons 176`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -9087,7 +8733,6 @@ exports[`Icon renders all icons 177`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -9095,7 +8740,6 @@ exports[`Icon renders all icons 177`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -9139,7 +8783,6 @@ exports[`Icon renders all icons 178`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -9147,7 +8790,6 @@ exports[`Icon renders all icons 178`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -9190,7 +8832,6 @@ exports[`Icon renders all icons 179`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -9198,7 +8839,6 @@ exports[`Icon renders all icons 179`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -9240,7 +8880,6 @@ exports[`Icon renders all icons 180`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -9248,7 +8887,6 @@ exports[`Icon renders all icons 180`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -9290,7 +8928,6 @@ exports[`Icon renders all icons 181`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -9298,7 +8935,6 @@ exports[`Icon renders all icons 181`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -9341,7 +8977,6 @@ exports[`Icon renders all icons 182`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -9349,7 +8984,6 @@ exports[`Icon renders all icons 182`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -9392,7 +9026,6 @@ exports[`Icon renders all icons 183`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -9400,7 +9033,6 @@ exports[`Icon renders all icons 183`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -9443,7 +9075,6 @@ exports[`Icon renders all icons 184`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -9451,7 +9082,6 @@ exports[`Icon renders all icons 184`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -9493,7 +9123,6 @@ exports[`Icon renders all icons 185`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -9501,7 +9130,6 @@ exports[`Icon renders all icons 185`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -9544,7 +9172,6 @@ exports[`Icon renders all icons 186`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -9552,7 +9179,6 @@ exports[`Icon renders all icons 186`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -9596,7 +9222,6 @@ exports[`Icon renders all icons 187`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -9604,7 +9229,6 @@ exports[`Icon renders all icons 187`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -9647,7 +9271,6 @@ exports[`Icon renders all icons 188`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -9655,7 +9278,6 @@ exports[`Icon renders all icons 188`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -9697,7 +9319,6 @@ exports[`Icon renders all icons 189`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -9705,7 +9326,6 @@ exports[`Icon renders all icons 189`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -9748,7 +9368,6 @@ exports[`Icon renders all icons 190`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -9756,7 +9375,6 @@ exports[`Icon renders all icons 190`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -9799,7 +9417,6 @@ exports[`Icon renders all icons 191`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -9807,7 +9424,6 @@ exports[`Icon renders all icons 191`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -9850,7 +9466,6 @@ exports[`Icon renders all icons 192`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -9858,7 +9473,6 @@ exports[`Icon renders all icons 192`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -9901,7 +9515,6 @@ exports[`Icon renders all icons 193`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -9909,7 +9522,6 @@ exports[`Icon renders all icons 193`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -9952,7 +9564,6 @@ exports[`Icon renders all icons 194`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -9960,7 +9571,6 @@ exports[`Icon renders all icons 194`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -10003,7 +9613,6 @@ exports[`Icon renders all icons 195`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -10011,7 +9620,6 @@ exports[`Icon renders all icons 195`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -10054,7 +9662,6 @@ exports[`Icon renders all icons 196`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -10062,7 +9669,6 @@ exports[`Icon renders all icons 196`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -10105,7 +9711,6 @@ exports[`Icon renders all icons 197`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -10113,7 +9718,6 @@ exports[`Icon renders all icons 197`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -10156,7 +9760,6 @@ exports[`Icon renders all icons 198`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -10164,7 +9767,6 @@ exports[`Icon renders all icons 198`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -10207,7 +9809,6 @@ exports[`Icon renders all icons 199`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -10215,7 +9816,6 @@ exports[`Icon renders all icons 199`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -10258,7 +9858,6 @@ exports[`Icon renders all icons 200`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -10266,7 +9865,6 @@ exports[`Icon renders all icons 200`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -10309,7 +9907,6 @@ exports[`Icon renders all icons 201`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -10317,7 +9914,6 @@ exports[`Icon renders all icons 201`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -10360,7 +9956,6 @@ exports[`Icon renders all icons 202`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -10368,7 +9963,6 @@ exports[`Icon renders all icons 202`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -10411,7 +10005,6 @@ exports[`Icon renders all icons 203`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -10419,7 +10012,6 @@ exports[`Icon renders all icons 203`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -10462,7 +10054,6 @@ exports[`Icon renders all icons 204`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -10470,7 +10061,6 @@ exports[`Icon renders all icons 204`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -10513,7 +10103,6 @@ exports[`Icon renders all icons 205`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -10521,7 +10110,6 @@ exports[`Icon renders all icons 205`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -10564,7 +10152,6 @@ exports[`Icon renders all icons 206`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -10572,7 +10159,6 @@ exports[`Icon renders all icons 206`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -10615,7 +10201,6 @@ exports[`Icon renders all icons 207`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -10623,7 +10208,6 @@ exports[`Icon renders all icons 207`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -10666,7 +10250,6 @@ exports[`Icon renders all icons 208`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -10674,7 +10257,6 @@ exports[`Icon renders all icons 208`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -10718,7 +10300,6 @@ exports[`Icon renders all icons 209`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -10726,7 +10307,6 @@ exports[`Icon renders all icons 209`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -10770,7 +10350,6 @@ exports[`Icon renders all icons 210`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -10778,7 +10357,6 @@ exports[`Icon renders all icons 210`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -10821,7 +10399,6 @@ exports[`Icon renders all icons 211`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -10829,7 +10406,6 @@ exports[`Icon renders all icons 211`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -10872,7 +10448,6 @@ exports[`Icon renders all icons 212`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -10880,7 +10455,6 @@ exports[`Icon renders all icons 212`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -10923,7 +10497,6 @@ exports[`Icon renders all icons 213`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -10931,7 +10504,6 @@ exports[`Icon renders all icons 213`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -10974,7 +10546,6 @@ exports[`Icon renders all icons 214`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -10982,7 +10553,6 @@ exports[`Icon renders all icons 214`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -11025,7 +10595,6 @@ exports[`Icon renders all icons 215`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -11033,7 +10602,6 @@ exports[`Icon renders all icons 215`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -11077,7 +10645,6 @@ exports[`Icon renders all icons 216`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -11085,7 +10652,6 @@ exports[`Icon renders all icons 216`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -11128,7 +10694,6 @@ exports[`Icon renders all icons 217`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -11136,7 +10701,6 @@ exports[`Icon renders all icons 217`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -11179,7 +10743,6 @@ exports[`Icon renders all icons 218`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -11187,7 +10750,6 @@ exports[`Icon renders all icons 218`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -11230,7 +10792,6 @@ exports[`Icon renders all icons 219`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -11238,7 +10799,6 @@ exports[`Icon renders all icons 219`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -11281,7 +10841,6 @@ exports[`Icon renders all icons 220`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -11289,7 +10848,6 @@ exports[`Icon renders all icons 220`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -11331,7 +10889,6 @@ exports[`Icon renders all icons 221`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -11339,7 +10896,6 @@ exports[`Icon renders all icons 221`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -11382,7 +10938,6 @@ exports[`Icon renders all icons 222`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -11390,7 +10945,6 @@ exports[`Icon renders all icons 222`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -11433,7 +10987,6 @@ exports[`Icon renders all icons 223`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -11441,7 +10994,6 @@ exports[`Icon renders all icons 223`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -11484,7 +11036,6 @@ exports[`Icon renders all icons 224`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -11492,7 +11043,6 @@ exports[`Icon renders all icons 224`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -11534,7 +11084,6 @@ exports[`Icon renders all icons 225`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -11542,7 +11091,6 @@ exports[`Icon renders all icons 225`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -11585,7 +11133,6 @@ exports[`Icon renders all icons 226`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -11593,7 +11140,6 @@ exports[`Icon renders all icons 226`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -11646,7 +11192,6 @@ exports[`Icon renders all icons 227`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -11654,7 +11199,6 @@ exports[`Icon renders all icons 227`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -11696,7 +11240,6 @@ exports[`Icon renders all icons 228`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -11704,7 +11247,6 @@ exports[`Icon renders all icons 228`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -11746,7 +11288,6 @@ exports[`Icon renders all icons 229`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -11754,7 +11295,6 @@ exports[`Icon renders all icons 229`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -11807,7 +11347,6 @@ exports[`Icon renders all icons 230`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -11815,7 +11354,6 @@ exports[`Icon renders all icons 230`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -11858,7 +11396,6 @@ exports[`Icon renders all icons 231`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -11866,7 +11403,6 @@ exports[`Icon renders all icons 231`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -11909,7 +11445,6 @@ exports[`Icon renders all icons 232`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -11917,7 +11452,6 @@ exports[`Icon renders all icons 232`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -11960,7 +11494,6 @@ exports[`Icon renders all icons 233`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -11968,7 +11501,6 @@ exports[`Icon renders all icons 233`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -12011,7 +11543,6 @@ exports[`Icon renders all icons 234`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -12019,7 +11550,6 @@ exports[`Icon renders all icons 234`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -12062,7 +11592,6 @@ exports[`Icon renders all icons 235`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -12070,7 +11599,6 @@ exports[`Icon renders all icons 235`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -12112,7 +11640,6 @@ exports[`Icon renders all icons 236`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -12120,7 +11647,6 @@ exports[`Icon renders all icons 236`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -12163,7 +11689,6 @@ exports[`Icon renders all icons 237`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -12171,7 +11696,6 @@ exports[`Icon renders all icons 237`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -12214,7 +11738,6 @@ exports[`Icon renders all icons 238`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -12222,7 +11745,6 @@ exports[`Icon renders all icons 238`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -12264,7 +11786,6 @@ exports[`Icon renders all icons 239`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -12272,7 +11793,6 @@ exports[`Icon renders all icons 239`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -12315,7 +11835,6 @@ exports[`Icon renders all icons 240`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -12323,7 +11842,6 @@ exports[`Icon renders all icons 240`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -12366,7 +11884,6 @@ exports[`Icon renders all icons 241`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -12374,7 +11891,6 @@ exports[`Icon renders all icons 241`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -12416,7 +11932,6 @@ exports[`Icon renders all icons 242`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -12424,7 +11939,6 @@ exports[`Icon renders all icons 242`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -12467,7 +11981,6 @@ exports[`Icon renders all icons 243`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -12475,7 +11988,6 @@ exports[`Icon renders all icons 243`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -12518,7 +12030,6 @@ exports[`Icon renders all icons 244`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -12526,7 +12037,6 @@ exports[`Icon renders all icons 244`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -12568,7 +12078,6 @@ exports[`Icon renders all icons 245`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -12576,7 +12085,6 @@ exports[`Icon renders all icons 245`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -12619,7 +12127,6 @@ exports[`Icon renders all icons 246`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -12627,7 +12134,6 @@ exports[`Icon renders all icons 246`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -12673,7 +12179,6 @@ exports[`Icon renders all icons 247`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -12681,7 +12186,6 @@ exports[`Icon renders all icons 247`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -12723,7 +12227,6 @@ exports[`Icon renders all icons 248`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -12731,7 +12234,6 @@ exports[`Icon renders all icons 248`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -12774,7 +12276,6 @@ exports[`Icon renders all icons 249`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -12782,7 +12283,6 @@ exports[`Icon renders all icons 249`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -12825,7 +12325,6 @@ exports[`Icon renders all icons 250`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -12833,7 +12332,6 @@ exports[`Icon renders all icons 250`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -12876,7 +12374,6 @@ exports[`Icon renders all icons 251`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -12884,7 +12381,6 @@ exports[`Icon renders all icons 251`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -12927,7 +12423,6 @@ exports[`Icon renders all icons 252`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -12935,7 +12430,6 @@ exports[`Icon renders all icons 252`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -12978,7 +12472,6 @@ exports[`Icon renders all icons 253`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -12986,7 +12479,6 @@ exports[`Icon renders all icons 253`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -13029,7 +12521,6 @@ exports[`Icon renders all icons 254`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -13037,7 +12528,6 @@ exports[`Icon renders all icons 254`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -13080,7 +12570,6 @@ exports[`Icon renders all icons 255`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -13088,7 +12577,6 @@ exports[`Icon renders all icons 255`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -13131,7 +12619,6 @@ exports[`Icon renders all icons 256`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -13139,7 +12626,6 @@ exports[`Icon renders all icons 256`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -13182,7 +12668,6 @@ exports[`Icon renders all icons 257`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -13190,7 +12675,6 @@ exports[`Icon renders all icons 257`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -13233,7 +12717,6 @@ exports[`Icon renders all icons 258`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -13241,7 +12724,6 @@ exports[`Icon renders all icons 258`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -13283,7 +12765,6 @@ exports[`Icon renders all icons 259`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -13291,7 +12772,6 @@ exports[`Icon renders all icons 259`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -13335,7 +12815,6 @@ exports[`Icon renders all icons 260`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -13343,7 +12822,6 @@ exports[`Icon renders all icons 260`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -13386,7 +12864,6 @@ exports[`Icon renders all icons 261`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -13394,7 +12871,6 @@ exports[`Icon renders all icons 261`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -13437,7 +12913,6 @@ exports[`Icon renders all icons 262`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -13445,7 +12920,6 @@ exports[`Icon renders all icons 262`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -13487,7 +12961,6 @@ exports[`Icon renders all icons 263`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -13495,7 +12968,6 @@ exports[`Icon renders all icons 263`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -13535,7 +13007,6 @@ exports[`Icon renders all icons 264`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -13543,7 +13014,6 @@ exports[`Icon renders all icons 264`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -13586,7 +13056,6 @@ exports[`Icon renders all icons 265`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -13594,7 +13063,6 @@ exports[`Icon renders all icons 265`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -13637,7 +13105,6 @@ exports[`Icon renders all icons 266`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -13645,7 +13112,6 @@ exports[`Icon renders all icons 266`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -13688,7 +13154,6 @@ exports[`Icon renders all icons 267`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -13696,7 +13161,6 @@ exports[`Icon renders all icons 267`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -13739,7 +13203,6 @@ exports[`Icon renders all icons 268`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -13747,7 +13210,6 @@ exports[`Icon renders all icons 268`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -13790,7 +13252,6 @@ exports[`Icon renders all icons 269`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -13798,7 +13259,6 @@ exports[`Icon renders all icons 269`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -13841,7 +13301,6 @@ exports[`Icon renders all icons 270`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -13849,7 +13308,6 @@ exports[`Icon renders all icons 270`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -13892,7 +13350,6 @@ exports[`Icon renders all icons 271`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -13900,7 +13357,6 @@ exports[`Icon renders all icons 271`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -13943,7 +13399,6 @@ exports[`Icon renders all icons 272`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -13951,7 +13406,6 @@ exports[`Icon renders all icons 272`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -13995,7 +13449,6 @@ exports[`Icon renders all icons 273`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -14003,7 +13456,6 @@ exports[`Icon renders all icons 273`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -14047,7 +13499,6 @@ exports[`Icon renders all icons 274`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -14055,7 +13506,6 @@ exports[`Icon renders all icons 274`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -14098,7 +13548,6 @@ exports[`Icon renders all icons 275`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -14106,7 +13555,6 @@ exports[`Icon renders all icons 275`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -14150,7 +13598,6 @@ exports[`Icon renders all icons 276`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -14158,7 +13605,6 @@ exports[`Icon renders all icons 276`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -14201,7 +13647,6 @@ exports[`Icon renders all icons 277`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -14209,7 +13654,6 @@ exports[`Icon renders all icons 277`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -14252,7 +13696,6 @@ exports[`Icon renders all icons 278`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -14260,7 +13703,6 @@ exports[`Icon renders all icons 278`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -14303,7 +13745,6 @@ exports[`Icon renders all icons 279`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -14311,7 +13752,6 @@ exports[`Icon renders all icons 279`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -14353,7 +13793,6 @@ exports[`Icon renders all icons 280`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -14361,7 +13800,6 @@ exports[`Icon renders all icons 280`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -14403,7 +13841,6 @@ exports[`Icon renders all icons 281`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -14411,7 +13848,6 @@ exports[`Icon renders all icons 281`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -14454,7 +13890,6 @@ exports[`Icon renders all icons 282`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -14462,7 +13897,6 @@ exports[`Icon renders all icons 282`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -14505,7 +13939,6 @@ exports[`Icon renders all icons 283`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -14513,7 +13946,6 @@ exports[`Icon renders all icons 283`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -14556,7 +13988,6 @@ exports[`Icon renders all icons 284`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -14564,7 +13995,6 @@ exports[`Icon renders all icons 284`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -14607,7 +14037,6 @@ exports[`Icon renders all icons 285`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -14615,7 +14044,6 @@ exports[`Icon renders all icons 285`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -14658,7 +14086,6 @@ exports[`Icon renders all icons 286`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -14666,7 +14093,6 @@ exports[`Icon renders all icons 286`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -14709,7 +14135,6 @@ exports[`Icon renders all icons 287`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -14717,7 +14142,6 @@ exports[`Icon renders all icons 287`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -14760,7 +14184,6 @@ exports[`Icon renders all icons 288`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -14768,7 +14191,6 @@ exports[`Icon renders all icons 288`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -14811,7 +14233,6 @@ exports[`Icon renders all icons 289`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -14819,7 +14240,6 @@ exports[`Icon renders all icons 289`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -14862,7 +14282,6 @@ exports[`Icon renders all icons 290`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -14870,7 +14289,6 @@ exports[`Icon renders all icons 290`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -14912,7 +14330,6 @@ exports[`Icon renders all icons 291`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -14920,7 +14337,6 @@ exports[`Icon renders all icons 291`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -14962,7 +14378,6 @@ exports[`Icon renders all icons 292`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -14970,7 +14385,6 @@ exports[`Icon renders all icons 292`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -15013,7 +14427,6 @@ exports[`Icon renders all icons 293`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -15021,7 +14434,6 @@ exports[`Icon renders all icons 293`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -15064,7 +14476,6 @@ exports[`Icon renders all icons 294`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -15072,7 +14483,6 @@ exports[`Icon renders all icons 294`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -15115,7 +14525,6 @@ exports[`Icon renders all icons 295`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -15123,7 +14532,6 @@ exports[`Icon renders all icons 295`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -15178,7 +14586,6 @@ exports[`Icon renders all icons 296`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -15186,7 +14593,6 @@ exports[`Icon renders all icons 296`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -15228,7 +14634,6 @@ exports[`Icon renders all icons 297`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -15236,7 +14641,6 @@ exports[`Icon renders all icons 297`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -15279,7 +14683,6 @@ exports[`Icon renders all icons 298`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -15287,7 +14690,6 @@ exports[`Icon renders all icons 298`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -15329,7 +14731,6 @@ exports[`Icon renders all icons 299`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -15337,7 +14738,6 @@ exports[`Icon renders all icons 299`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -15380,7 +14780,6 @@ exports[`Icon renders all icons 300`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -15388,7 +14787,6 @@ exports[`Icon renders all icons 300`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -15431,7 +14829,6 @@ exports[`Icon renders all icons 301`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -15439,7 +14836,6 @@ exports[`Icon renders all icons 301`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -15482,7 +14878,6 @@ exports[`Icon renders all icons 302`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -15490,7 +14885,6 @@ exports[`Icon renders all icons 302`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -15539,7 +14933,6 @@ exports[`Icon renders all icons 303`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -15547,7 +14940,6 @@ exports[`Icon renders all icons 303`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -15590,7 +14982,6 @@ exports[`Icon renders all icons 304`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -15598,7 +14989,6 @@ exports[`Icon renders all icons 304`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -15643,7 +15033,6 @@ exports[`Icon renders all icons 305`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -15651,7 +15040,6 @@ exports[`Icon renders all icons 305`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -15694,7 +15082,6 @@ exports[`Icon renders all icons 306`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -15702,7 +15089,6 @@ exports[`Icon renders all icons 306`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -15745,7 +15131,6 @@ exports[`Icon renders all icons 307`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -15753,7 +15138,6 @@ exports[`Icon renders all icons 307`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -15795,7 +15179,6 @@ exports[`Icon renders all icons 308`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -15803,7 +15186,6 @@ exports[`Icon renders all icons 308`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -15846,7 +15228,6 @@ exports[`Icon renders all icons 309`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -15854,7 +15235,6 @@ exports[`Icon renders all icons 309`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -15897,7 +15277,6 @@ exports[`Icon renders all icons 310`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -15905,7 +15284,6 @@ exports[`Icon renders all icons 310`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -15948,7 +15326,6 @@ exports[`Icon renders all icons 311`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -15956,7 +15333,6 @@ exports[`Icon renders all icons 311`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -15999,7 +15375,6 @@ exports[`Icon renders all icons 312`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -16007,7 +15382,6 @@ exports[`Icon renders all icons 312`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -16050,7 +15424,6 @@ exports[`Icon renders all icons 313`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -16058,7 +15431,6 @@ exports[`Icon renders all icons 313`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -16101,7 +15473,6 @@ exports[`Icon renders all icons 314`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -16109,7 +15480,6 @@ exports[`Icon renders all icons 314`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -16150,7 +15520,6 @@ exports[`Icon renders all icons 315`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -16158,7 +15527,6 @@ exports[`Icon renders all icons 315`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -16201,7 +15569,6 @@ exports[`Icon renders all icons 316`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -16209,7 +15576,6 @@ exports[`Icon renders all icons 316`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -16252,7 +15618,6 @@ exports[`Icon renders all icons 317`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -16260,7 +15625,6 @@ exports[`Icon renders all icons 317`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -16303,7 +15667,6 @@ exports[`Icon renders all icons 318`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -16311,7 +15674,6 @@ exports[`Icon renders all icons 318`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -16354,7 +15716,6 @@ exports[`Icon renders all icons 319`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -16362,7 +15723,6 @@ exports[`Icon renders all icons 319`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -16405,7 +15765,6 @@ exports[`Icon renders all icons 320`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -16413,7 +15772,6 @@ exports[`Icon renders all icons 320`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -16456,7 +15814,6 @@ exports[`Icon renders all icons 321`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -16464,7 +15821,6 @@ exports[`Icon renders all icons 321`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -16506,7 +15862,6 @@ exports[`Icon renders all icons 322`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -16514,7 +15869,6 @@ exports[`Icon renders all icons 322`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -16556,7 +15910,6 @@ exports[`Icon renders all icons 323`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -16564,7 +15917,6 @@ exports[`Icon renders all icons 323`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -16607,7 +15959,6 @@ exports[`Icon renders all icons 324`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -16615,7 +15966,6 @@ exports[`Icon renders all icons 324`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -16657,7 +16007,6 @@ exports[`Icon renders all icons 325`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -16665,7 +16014,6 @@ exports[`Icon renders all icons 325`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -16729,7 +16077,6 @@ exports[`Icon renders all icons 326`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -16737,7 +16084,6 @@ exports[`Icon renders all icons 326`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -16780,7 +16126,6 @@ exports[`Icon renders all icons 327`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -16788,7 +16133,6 @@ exports[`Icon renders all icons 327`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -16831,7 +16175,6 @@ exports[`Icon renders all icons 328`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -16839,7 +16182,6 @@ exports[`Icon renders all icons 328`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -16882,7 +16224,6 @@ exports[`Icon renders all icons 329`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -16890,7 +16231,6 @@ exports[`Icon renders all icons 329`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -16933,7 +16273,6 @@ exports[`Icon renders all icons 330`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -16941,7 +16280,6 @@ exports[`Icon renders all icons 330`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -16984,7 +16322,6 @@ exports[`Icon renders all icons 331`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -16992,7 +16329,6 @@ exports[`Icon renders all icons 331`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -17035,7 +16371,6 @@ exports[`Icon renders all icons 332`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -17043,7 +16378,6 @@ exports[`Icon renders all icons 332`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -17085,7 +16419,6 @@ exports[`Icon renders all icons 333`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -17093,7 +16426,6 @@ exports[`Icon renders all icons 333`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -17138,7 +16470,6 @@ exports[`Icon renders all icons 334`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -17146,7 +16477,6 @@ exports[`Icon renders all icons 334`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -17189,7 +16519,6 @@ exports[`Icon renders all icons 335`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -17197,7 +16526,6 @@ exports[`Icon renders all icons 335`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -17240,7 +16568,6 @@ exports[`Icon renders all icons 336`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -17248,7 +16575,6 @@ exports[`Icon renders all icons 336`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -17290,7 +16616,6 @@ exports[`Icon renders all icons 337`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -17298,7 +16623,6 @@ exports[`Icon renders all icons 337`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -17341,7 +16665,6 @@ exports[`Icon renders all icons 338`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -17349,7 +16672,6 @@ exports[`Icon renders all icons 338`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -17391,7 +16713,6 @@ exports[`Icon renders all icons 339`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -17399,7 +16720,6 @@ exports[`Icon renders all icons 339`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -17442,7 +16762,6 @@ exports[`Icon renders all icons 340`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -17450,7 +16769,6 @@ exports[`Icon renders all icons 340`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -17493,7 +16811,6 @@ exports[`Icon renders all icons 341`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -17501,7 +16818,6 @@ exports[`Icon renders all icons 341`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -17544,7 +16860,6 @@ exports[`Icon renders all icons 342`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -17552,7 +16867,6 @@ exports[`Icon renders all icons 342`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -17595,7 +16909,6 @@ exports[`Icon renders all icons 343`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -17603,7 +16916,6 @@ exports[`Icon renders all icons 343`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -17647,7 +16959,6 @@ exports[`Icon renders all icons 344`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -17655,7 +16966,6 @@ exports[`Icon renders all icons 344`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -17698,7 +17008,6 @@ exports[`Icon renders all icons 345`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -17706,7 +17015,6 @@ exports[`Icon renders all icons 345`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -17748,7 +17056,6 @@ exports[`Icon renders all icons 346`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -17756,7 +17063,6 @@ exports[`Icon renders all icons 346`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -17799,7 +17105,6 @@ exports[`Icon renders all icons 347`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -17807,7 +17112,6 @@ exports[`Icon renders all icons 347`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -17852,7 +17156,6 @@ exports[`Icon renders all icons 348`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -17860,7 +17163,6 @@ exports[`Icon renders all icons 348`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -17902,7 +17204,6 @@ exports[`Icon renders all icons 349`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -17910,7 +17211,6 @@ exports[`Icon renders all icons 349`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -17961,7 +17261,6 @@ exports[`Icon renders all icons 350`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -17969,7 +17268,6 @@ exports[`Icon renders all icons 350`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -18011,7 +17309,6 @@ exports[`Icon renders all icons 351`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -18019,7 +17316,6 @@ exports[`Icon renders all icons 351`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -18061,7 +17357,6 @@ exports[`Icon renders all icons 352`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -18069,7 +17364,6 @@ exports[`Icon renders all icons 352`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -18109,7 +17403,6 @@ exports[`Icon renders all icons 353`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -18117,7 +17410,6 @@ exports[`Icon renders all icons 353`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -18160,7 +17452,6 @@ exports[`Icon renders all icons 354`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -18168,7 +17459,6 @@ exports[`Icon renders all icons 354`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -18211,7 +17501,6 @@ exports[`Icon renders all icons 355`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -18219,7 +17508,6 @@ exports[`Icon renders all icons 355`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -18262,7 +17550,6 @@ exports[`Icon renders all icons 356`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -18270,7 +17557,6 @@ exports[`Icon renders all icons 356`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -18315,7 +17601,6 @@ exports[`Icon renders all icons 357`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -18323,7 +17608,6 @@ exports[`Icon renders all icons 357`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -18368,7 +17652,6 @@ exports[`Icon renders all icons 358`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -18376,7 +17659,6 @@ exports[`Icon renders all icons 358`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -18420,7 +17702,6 @@ exports[`Icon renders all icons 359`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -18428,7 +17709,6 @@ exports[`Icon renders all icons 359`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -18471,7 +17751,6 @@ exports[`Icon renders all icons 360`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -18479,7 +17758,6 @@ exports[`Icon renders all icons 360`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -18522,7 +17800,6 @@ exports[`Icon renders all icons 361`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -18530,7 +17807,6 @@ exports[`Icon renders all icons 361`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -18573,7 +17849,6 @@ exports[`Icon renders all icons 362`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -18581,7 +17856,6 @@ exports[`Icon renders all icons 362`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -18624,7 +17898,6 @@ exports[`Icon renders all icons 363`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -18632,7 +17905,6 @@ exports[`Icon renders all icons 363`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -18675,7 +17947,6 @@ exports[`Icon renders all icons 364`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -18683,7 +17954,6 @@ exports[`Icon renders all icons 364`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -18723,7 +17993,6 @@ exports[`Icon renders all icons 365`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -18731,7 +18000,6 @@ exports[`Icon renders all icons 365`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -18771,7 +18039,6 @@ exports[`Icon renders all icons 366`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -18779,7 +18046,6 @@ exports[`Icon renders all icons 366`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -18822,7 +18088,6 @@ exports[`Icon renders all icons 367`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -18830,7 +18095,6 @@ exports[`Icon renders all icons 367`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -18875,7 +18139,6 @@ exports[`Icon renders all icons 368`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -18883,7 +18146,6 @@ exports[`Icon renders all icons 368`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -18925,7 +18187,6 @@ exports[`Icon renders all icons 369`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -18933,7 +18194,6 @@ exports[`Icon renders all icons 369`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -18976,7 +18236,6 @@ exports[`Icon renders all icons 370`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -18984,7 +18243,6 @@ exports[`Icon renders all icons 370`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -19027,7 +18285,6 @@ exports[`Icon renders all icons 371`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -19035,7 +18292,6 @@ exports[`Icon renders all icons 371`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -19079,7 +18335,6 @@ exports[`Icon renders all icons 372`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -19087,7 +18342,6 @@ exports[`Icon renders all icons 372`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -19130,7 +18384,6 @@ exports[`Icon renders all icons 373`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -19138,7 +18391,6 @@ exports[`Icon renders all icons 373`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -19181,7 +18433,6 @@ exports[`Icon renders all icons 374`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -19189,7 +18440,6 @@ exports[`Icon renders all icons 374`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -19232,7 +18482,6 @@ exports[`Icon renders all icons 375`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -19240,7 +18489,6 @@ exports[`Icon renders all icons 375`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -19283,7 +18531,6 @@ exports[`Icon renders all icons 376`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -19291,7 +18538,6 @@ exports[`Icon renders all icons 376`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -19333,7 +18579,6 @@ exports[`Icon renders all icons 377`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -19341,7 +18586,6 @@ exports[`Icon renders all icons 377`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -19384,7 +18628,6 @@ exports[`Icon renders all icons 378`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -19392,7 +18635,6 @@ exports[`Icon renders all icons 378`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -19435,7 +18677,6 @@ exports[`Icon renders all icons 379`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -19443,7 +18684,6 @@ exports[`Icon renders all icons 379`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -19486,7 +18726,6 @@ exports[`Icon renders all icons 380`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -19494,7 +18733,6 @@ exports[`Icon renders all icons 380`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -19537,7 +18775,6 @@ exports[`Icon renders all icons 381`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -19545,7 +18782,6 @@ exports[`Icon renders all icons 381`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -19588,7 +18824,6 @@ exports[`Icon renders all icons 382`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -19596,7 +18831,6 @@ exports[`Icon renders all icons 382`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -19639,7 +18873,6 @@ exports[`Icon renders all icons 383`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -19647,7 +18880,6 @@ exports[`Icon renders all icons 383`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -19690,7 +18922,6 @@ exports[`Icon renders all icons 384`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -19698,7 +18929,6 @@ exports[`Icon renders all icons 384`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -19741,7 +18971,6 @@ exports[`Icon renders all icons 385`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -19749,7 +18978,6 @@ exports[`Icon renders all icons 385`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -19792,7 +19020,6 @@ exports[`Icon renders all icons 386`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -19800,7 +19027,6 @@ exports[`Icon renders all icons 386`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -19843,7 +19069,6 @@ exports[`Icon renders all icons 387`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -19851,7 +19076,6 @@ exports[`Icon renders all icons 387`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -19894,7 +19118,6 @@ exports[`Icon renders all icons 388`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -19902,7 +19125,6 @@ exports[`Icon renders all icons 388`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -19945,7 +19167,6 @@ exports[`Icon renders all icons 389`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -19953,7 +19174,6 @@ exports[`Icon renders all icons 389`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -19996,7 +19216,6 @@ exports[`Icon renders all icons 390`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -20004,7 +19223,6 @@ exports[`Icon renders all icons 390`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -20047,7 +19265,6 @@ exports[`Icon renders all icons 391`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -20055,7 +19272,6 @@ exports[`Icon renders all icons 391`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -20098,7 +19314,6 @@ exports[`Icon renders all icons 392`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -20106,7 +19321,6 @@ exports[`Icon renders all icons 392`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -20149,7 +19363,6 @@ exports[`Icon renders all icons 393`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -20157,7 +19370,6 @@ exports[`Icon renders all icons 393`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -20200,7 +19412,6 @@ exports[`Icon renders all icons 394`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -20208,7 +19419,6 @@ exports[`Icon renders all icons 394`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -20251,7 +19461,6 @@ exports[`Icon renders all icons 395`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -20259,7 +19468,6 @@ exports[`Icon renders all icons 395`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -20302,7 +19510,6 @@ exports[`Icon renders all icons 396`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -20310,7 +19517,6 @@ exports[`Icon renders all icons 396`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -20354,7 +19560,6 @@ exports[`Icon renders all icons 397`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -20362,7 +19567,6 @@ exports[`Icon renders all icons 397`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -20405,7 +19609,6 @@ exports[`Icon renders all icons 398`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -20413,7 +19616,6 @@ exports[`Icon renders all icons 398`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -20456,7 +19658,6 @@ exports[`Icon renders all icons 399`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -20464,7 +19665,6 @@ exports[`Icon renders all icons 399`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -20506,7 +19706,6 @@ exports[`Icon renders all icons 400`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -20514,7 +19713,6 @@ exports[`Icon renders all icons 400`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -20556,7 +19754,6 @@ exports[`Icon renders all icons 401`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -20564,7 +19761,6 @@ exports[`Icon renders all icons 401`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -20606,7 +19802,6 @@ exports[`Icon renders all icons 402`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -20614,7 +19809,6 @@ exports[`Icon renders all icons 402`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -20656,7 +19850,6 @@ exports[`Icon renders all icons 403`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -20664,7 +19857,6 @@ exports[`Icon renders all icons 403`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -20707,7 +19899,6 @@ exports[`Icon renders all icons 404`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -20715,7 +19906,6 @@ exports[`Icon renders all icons 404`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -20758,7 +19948,6 @@ exports[`Icon renders all icons 405`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -20766,7 +19955,6 @@ exports[`Icon renders all icons 405`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -20809,7 +19997,6 @@ exports[`Icon renders all icons 406`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -20817,7 +20004,6 @@ exports[`Icon renders all icons 406`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -20860,7 +20046,6 @@ exports[`Icon renders all icons 407`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -20868,7 +20053,6 @@ exports[`Icon renders all icons 407`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -20910,7 +20094,6 @@ exports[`Icon renders all icons 408`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -20918,7 +20101,6 @@ exports[`Icon renders all icons 408`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -20960,7 +20142,6 @@ exports[`Icon renders all icons 409`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -20968,7 +20149,6 @@ exports[`Icon renders all icons 409`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -21011,7 +20191,6 @@ exports[`Icon renders all icons 410`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -21019,7 +20198,6 @@ exports[`Icon renders all icons 410`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -21070,7 +20248,6 @@ exports[`Icon renders all icons 411`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -21078,7 +20255,6 @@ exports[`Icon renders all icons 411`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -21120,7 +20296,6 @@ exports[`Icon renders all icons 412`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -21128,7 +20303,6 @@ exports[`Icon renders all icons 412`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -21170,7 +20344,6 @@ exports[`Icon renders all icons 413`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -21178,7 +20351,6 @@ exports[`Icon renders all icons 413`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -21221,7 +20393,6 @@ exports[`Icon renders all icons 414`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -21229,7 +20400,6 @@ exports[`Icon renders all icons 414`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -21275,7 +20445,6 @@ exports[`Icon renders all icons 415`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -21283,7 +20452,6 @@ exports[`Icon renders all icons 415`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -21326,7 +20494,6 @@ exports[`Icon renders all icons 416`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -21334,7 +20501,6 @@ exports[`Icon renders all icons 416`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -21378,7 +20544,6 @@ exports[`Icon renders all icons 417`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -21386,7 +20551,6 @@ exports[`Icon renders all icons 417`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -21429,7 +20593,6 @@ exports[`Icon renders all icons 418`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -21437,7 +20600,6 @@ exports[`Icon renders all icons 418`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -21483,7 +20645,6 @@ exports[`Icon renders all icons 419`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -21491,7 +20652,6 @@ exports[`Icon renders all icons 419`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -21534,7 +20694,6 @@ exports[`Icon renders all icons 420`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -21542,7 +20701,6 @@ exports[`Icon renders all icons 420`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -21588,7 +20746,6 @@ exports[`Icon renders all icons 421`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -21596,7 +20753,6 @@ exports[`Icon renders all icons 421`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -21643,7 +20799,6 @@ exports[`Icon renders all icons 422`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -21651,7 +20806,6 @@ exports[`Icon renders all icons 422`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -21697,7 +20851,6 @@ exports[`Icon renders all icons 423`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -21705,7 +20858,6 @@ exports[`Icon renders all icons 423`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -21748,7 +20900,6 @@ exports[`Icon renders all icons 424`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -21756,7 +20907,6 @@ exports[`Icon renders all icons 424`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -21799,7 +20949,6 @@ exports[`Icon renders all icons 425`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -21807,7 +20956,6 @@ exports[`Icon renders all icons 425`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -21851,7 +20999,6 @@ exports[`Icon renders all icons 426`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -21859,7 +21006,6 @@ exports[`Icon renders all icons 426`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -21902,7 +21048,6 @@ exports[`Icon renders all icons 427`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -21910,7 +21055,6 @@ exports[`Icon renders all icons 427`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -21953,7 +21097,6 @@ exports[`Icon renders all icons 428`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -21961,7 +21104,6 @@ exports[`Icon renders all icons 428`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -22004,7 +21146,6 @@ exports[`Icon renders all icons 429`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -22012,7 +21153,6 @@ exports[`Icon renders all icons 429`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -22058,7 +21198,6 @@ exports[`Icon renders all icons 430`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -22066,7 +21205,6 @@ exports[`Icon renders all icons 430`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -22109,7 +21247,6 @@ exports[`Icon renders all icons 431`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -22117,7 +21254,6 @@ exports[`Icon renders all icons 431`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -22160,7 +21296,6 @@ exports[`Icon renders all icons 432`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -22168,7 +21303,6 @@ exports[`Icon renders all icons 432`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -22217,7 +21351,6 @@ exports[`Icon renders all icons 433`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -22225,7 +21358,6 @@ exports[`Icon renders all icons 433`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -22267,7 +21399,6 @@ exports[`Icon renders all icons 434`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -22275,7 +21406,6 @@ exports[`Icon renders all icons 434`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -22318,7 +21448,6 @@ exports[`Icon renders all icons 435`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -22326,7 +21455,6 @@ exports[`Icon renders all icons 435`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -22369,7 +21497,6 @@ exports[`Icon renders all icons 436`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -22377,7 +21504,6 @@ exports[`Icon renders all icons 436`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -22420,7 +21546,6 @@ exports[`Icon renders all icons 437`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -22428,7 +21553,6 @@ exports[`Icon renders all icons 437`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -22471,7 +21595,6 @@ exports[`Icon renders all icons 438`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -22479,7 +21602,6 @@ exports[`Icon renders all icons 438`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -22523,7 +21645,6 @@ exports[`Icon renders all icons 439`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -22531,7 +21652,6 @@ exports[`Icon renders all icons 439`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -22573,7 +21693,6 @@ exports[`Icon renders all icons 440`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -22581,7 +21700,6 @@ exports[`Icon renders all icons 440`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -22623,7 +21741,6 @@ exports[`Icon renders all icons 441`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -22631,7 +21748,6 @@ exports[`Icon renders all icons 441`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -22676,7 +21792,6 @@ exports[`Icon renders all icons 442`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -22684,7 +21799,6 @@ exports[`Icon renders all icons 442`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -22727,7 +21841,6 @@ exports[`Icon renders all icons 443`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -22735,7 +21848,6 @@ exports[`Icon renders all icons 443`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -22778,7 +21890,6 @@ exports[`Icon renders all icons 444`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -22786,7 +21897,6 @@ exports[`Icon renders all icons 444`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -22829,7 +21939,6 @@ exports[`Icon renders all icons 445`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -22837,7 +21946,6 @@ exports[`Icon renders all icons 445`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -22880,7 +21988,6 @@ exports[`Icon renders all icons 446`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -22888,7 +21995,6 @@ exports[`Icon renders all icons 446`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -22931,7 +22037,6 @@ exports[`Icon renders all icons 447`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -22939,7 +22044,6 @@ exports[`Icon renders all icons 447`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -22982,7 +22086,6 @@ exports[`Icon renders all icons 448`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -22990,7 +22093,6 @@ exports[`Icon renders all icons 448`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -23033,7 +22135,6 @@ exports[`Icon renders all icons 449`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -23041,7 +22142,6 @@ exports[`Icon renders all icons 449`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -23084,7 +22184,6 @@ exports[`Icon renders all icons 450`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -23092,7 +22191,6 @@ exports[`Icon renders all icons 450`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -23135,7 +22233,6 @@ exports[`Icon renders all icons 451`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -23143,7 +22240,6 @@ exports[`Icon renders all icons 451`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -23186,7 +22282,6 @@ exports[`Icon renders all icons 452`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -23194,7 +22289,6 @@ exports[`Icon renders all icons 452`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -23239,7 +22333,6 @@ exports[`Icon renders all icons 453`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -23247,7 +22340,6 @@ exports[`Icon renders all icons 453`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -23290,7 +22382,6 @@ exports[`Icon renders all icons 454`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -23298,7 +22389,6 @@ exports[`Icon renders all icons 454`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -23341,7 +22431,6 @@ exports[`Icon renders all icons 455`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -23349,7 +22438,6 @@ exports[`Icon renders all icons 455`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -23392,7 +22480,6 @@ exports[`Icon renders all icons 456`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -23400,7 +22487,6 @@ exports[`Icon renders all icons 456`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -23443,7 +22529,6 @@ exports[`Icon renders all icons 457`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -23451,7 +22536,6 @@ exports[`Icon renders all icons 457`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -23512,7 +22596,6 @@ exports[`Icon renders all icons 458`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -23520,7 +22603,6 @@ exports[`Icon renders all icons 458`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -23581,7 +22663,6 @@ exports[`Icon renders all icons 459`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -23589,7 +22670,6 @@ exports[`Icon renders all icons 459`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -23650,7 +22730,6 @@ exports[`Icon renders all icons 460`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -23658,7 +22737,6 @@ exports[`Icon renders all icons 460`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -23719,7 +22797,6 @@ exports[`Icon renders all icons 461`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -23727,7 +22804,6 @@ exports[`Icon renders all icons 461`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -23770,7 +22846,6 @@ exports[`Icon renders all icons 462`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -23778,7 +22853,6 @@ exports[`Icon renders all icons 462`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -23821,7 +22895,6 @@ exports[`Icon renders all icons 463`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -23829,7 +22902,6 @@ exports[`Icon renders all icons 463`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -23872,7 +22944,6 @@ exports[`Icon renders all icons 464`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -23880,7 +22951,6 @@ exports[`Icon renders all icons 464`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -23923,7 +22993,6 @@ exports[`Icon renders all icons 465`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -23931,7 +23000,6 @@ exports[`Icon renders all icons 465`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -23974,7 +23042,6 @@ exports[`Icon renders all icons 466`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -23982,7 +23049,6 @@ exports[`Icon renders all icons 466`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -24025,7 +23091,6 @@ exports[`Icon renders all icons 467`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -24033,7 +23098,6 @@ exports[`Icon renders all icons 467`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -24076,7 +23140,6 @@ exports[`Icon renders all icons 468`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -24084,7 +23147,6 @@ exports[`Icon renders all icons 468`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -24127,7 +23189,6 @@ exports[`Icon renders all icons 469`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -24135,7 +23196,6 @@ exports[`Icon renders all icons 469`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -24178,7 +23238,6 @@ exports[`Icon renders all icons 470`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -24186,7 +23245,6 @@ exports[`Icon renders all icons 470`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -24230,7 +23288,6 @@ exports[`Icon renders all icons 471`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -24238,7 +23295,6 @@ exports[`Icon renders all icons 471`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -24281,7 +23337,6 @@ exports[`Icon renders all icons 472`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -24289,7 +23344,6 @@ exports[`Icon renders all icons 472`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -24332,7 +23386,6 @@ exports[`Icon renders all icons 473`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -24340,7 +23393,6 @@ exports[`Icon renders all icons 473`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -24383,7 +23435,6 @@ exports[`Icon renders all icons 474`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -24391,7 +23442,6 @@ exports[`Icon renders all icons 474`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -24434,7 +23484,6 @@ exports[`Icon renders all icons 475`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -24442,7 +23491,6 @@ exports[`Icon renders all icons 475`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -24485,7 +23533,6 @@ exports[`Icon renders all icons 476`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -24493,7 +23540,6 @@ exports[`Icon renders all icons 476`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -24536,7 +23582,6 @@ exports[`Icon renders all icons 477`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -24544,7 +23589,6 @@ exports[`Icon renders all icons 477`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -24587,7 +23631,6 @@ exports[`Icon renders all icons 478`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -24595,7 +23638,6 @@ exports[`Icon renders all icons 478`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -24638,7 +23680,6 @@ exports[`Icon renders all icons 479`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -24646,7 +23687,6 @@ exports[`Icon renders all icons 479`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -24690,7 +23730,6 @@ exports[`Icon renders all icons 480`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -24698,7 +23737,6 @@ exports[`Icon renders all icons 480`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -24740,7 +23778,6 @@ exports[`Icon renders all icons 481`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -24748,7 +23785,6 @@ exports[`Icon renders all icons 481`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -24790,7 +23826,6 @@ exports[`Icon renders all icons 482`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -24798,7 +23833,6 @@ exports[`Icon renders all icons 482`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -24840,7 +23874,6 @@ exports[`Icon renders all icons 483`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -24848,7 +23881,6 @@ exports[`Icon renders all icons 483`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -24890,7 +23922,6 @@ exports[`Icon renders all icons 484`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -24898,7 +23929,6 @@ exports[`Icon renders all icons 484`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -24941,7 +23971,6 @@ exports[`Icon renders all icons 485`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -24949,7 +23978,6 @@ exports[`Icon renders all icons 485`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -24989,7 +24017,6 @@ exports[`Icon renders all icons 486`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -24997,7 +24024,6 @@ exports[`Icon renders all icons 486`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -25040,7 +24066,6 @@ exports[`Icon renders all icons 487`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -25048,7 +24073,6 @@ exports[`Icon renders all icons 487`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -25091,7 +24115,6 @@ exports[`Icon renders all icons 488`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -25099,7 +24122,6 @@ exports[`Icon renders all icons 488`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -25169,7 +24191,6 @@ exports[`Icon renders all icons 489`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -25177,7 +24198,6 @@ exports[`Icon renders all icons 489`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -25221,7 +24241,6 @@ exports[`Icon renders all icons 490`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -25229,7 +24248,6 @@ exports[`Icon renders all icons 490`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -25272,7 +24290,6 @@ exports[`Icon renders all icons 491`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -25280,7 +24297,6 @@ exports[`Icon renders all icons 491`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -25323,7 +24339,6 @@ exports[`Icon renders all icons 492`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -25331,7 +24346,6 @@ exports[`Icon renders all icons 492`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -25374,7 +24388,6 @@ exports[`Icon renders all icons 493`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -25382,7 +24395,6 @@ exports[`Icon renders all icons 493`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -25425,7 +24437,6 @@ exports[`Icon renders all icons 494`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -25433,7 +24444,6 @@ exports[`Icon renders all icons 494`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -25476,7 +24486,6 @@ exports[`Icon renders all icons 495`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -25484,7 +24493,6 @@ exports[`Icon renders all icons 495`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -25527,7 +24535,6 @@ exports[`Icon renders all icons 496`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -25535,7 +24542,6 @@ exports[`Icon renders all icons 496`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -25578,7 +24584,6 @@ exports[`Icon renders all icons 497`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -25586,7 +24591,6 @@ exports[`Icon renders all icons 497`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -25629,7 +24633,6 @@ exports[`Icon renders all icons 498`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -25637,7 +24640,6 @@ exports[`Icon renders all icons 498`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -25680,7 +24682,6 @@ exports[`Icon renders all icons 499`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -25688,7 +24689,6 @@ exports[`Icon renders all icons 499`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -25731,7 +24731,6 @@ exports[`Icon renders all icons 500`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -25739,7 +24738,6 @@ exports[`Icon renders all icons 500`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -25782,7 +24780,6 @@ exports[`Icon renders all icons 501`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -25790,7 +24787,6 @@ exports[`Icon renders all icons 501`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -25833,7 +24829,6 @@ exports[`Icon renders all icons 502`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -25841,7 +24836,6 @@ exports[`Icon renders all icons 502`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -25884,7 +24878,6 @@ exports[`Icon renders all icons 503`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -25892,7 +24885,6 @@ exports[`Icon renders all icons 503`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -25935,7 +24927,6 @@ exports[`Icon renders all icons 504`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -25943,7 +24934,6 @@ exports[`Icon renders all icons 504`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -25986,7 +24976,6 @@ exports[`Icon renders all icons 505`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -25994,7 +24983,6 @@ exports[`Icon renders all icons 505`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -26037,7 +25025,6 @@ exports[`Icon renders all icons 506`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -26045,7 +25032,6 @@ exports[`Icon renders all icons 506`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -26088,7 +25074,6 @@ exports[`Icon renders all icons 507`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -26096,7 +25081,6 @@ exports[`Icon renders all icons 507`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -26138,7 +25122,6 @@ exports[`Icon renders all icons 508`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -26146,7 +25129,6 @@ exports[`Icon renders all icons 508`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -26189,7 +25171,6 @@ exports[`Icon renders all icons 509`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -26197,7 +25178,6 @@ exports[`Icon renders all icons 509`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -26240,7 +25220,6 @@ exports[`Icon renders all icons 510`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -26248,7 +25227,6 @@ exports[`Icon renders all icons 510`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -26290,7 +25268,6 @@ exports[`Icon renders all icons 511`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -26298,7 +25275,6 @@ exports[`Icon renders all icons 511`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -26341,7 +25317,6 @@ exports[`Icon renders all icons 512`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -26349,7 +25324,6 @@ exports[`Icon renders all icons 512`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -26391,7 +25365,6 @@ exports[`Icon renders all icons 513`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -26399,7 +25372,6 @@ exports[`Icon renders all icons 513`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -26442,7 +25414,6 @@ exports[`Icon renders all icons 514`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -26450,7 +25421,6 @@ exports[`Icon renders all icons 514`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -26493,7 +25463,6 @@ exports[`Icon renders all icons 515`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -26501,7 +25470,6 @@ exports[`Icon renders all icons 515`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -26544,7 +25512,6 @@ exports[`Icon renders all icons 516`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -26552,7 +25519,6 @@ exports[`Icon renders all icons 516`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -26595,7 +25561,6 @@ exports[`Icon renders all icons 517`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -26603,7 +25568,6 @@ exports[`Icon renders all icons 517`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -26646,7 +25610,6 @@ exports[`Icon renders all icons 518`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -26654,7 +25617,6 @@ exports[`Icon renders all icons 518`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -26697,7 +25659,6 @@ exports[`Icon renders all icons 519`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -26705,7 +25666,6 @@ exports[`Icon renders all icons 519`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -26750,7 +25710,6 @@ exports[`Icon renders all icons 520`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -26758,7 +25717,6 @@ exports[`Icon renders all icons 520`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -26803,7 +25761,6 @@ exports[`Icon renders all icons 521`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -26811,7 +25768,6 @@ exports[`Icon renders all icons 521`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -26870,7 +25826,6 @@ exports[`Icon renders all icons 522`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -26878,7 +25833,6 @@ exports[`Icon renders all icons 522`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -26920,7 +25874,6 @@ exports[`Icon renders all icons 523`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -26928,7 +25881,6 @@ exports[`Icon renders all icons 523`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -26970,7 +25922,6 @@ exports[`Icon renders all icons 524`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -26978,7 +25929,6 @@ exports[`Icon renders all icons 524`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -27021,7 +25971,6 @@ exports[`Icon renders all icons 525`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -27029,7 +25978,6 @@ exports[`Icon renders all icons 525`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -27074,7 +26022,6 @@ exports[`Icon renders all icons 526`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -27082,7 +26029,6 @@ exports[`Icon renders all icons 526`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -27124,7 +26070,6 @@ exports[`Icon renders all icons 527`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -27132,7 +26077,6 @@ exports[`Icon renders all icons 527`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -27175,7 +26119,6 @@ exports[`Icon renders all icons 528`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -27183,7 +26126,6 @@ exports[`Icon renders all icons 528`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -27226,7 +26168,6 @@ exports[`Icon renders custom title 1`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -27234,7 +26175,6 @@ exports[`Icon renders custom title 1`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -27287,7 +26227,6 @@ exports[`Icon renders extra large 1`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -27295,7 +26234,6 @@ exports[`Icon renders extra large 1`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -27349,7 +26287,6 @@ exports[`Icon renders large 1`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -27357,7 +26294,6 @@ exports[`Icon renders large 1`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -27411,7 +26347,6 @@ exports[`Icon with ThemeProvider 1`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -27419,7 +26354,6 @@ exports[`Icon with ThemeProvider 1`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg
@@ -27473,7 +26407,6 @@ exports[`Icon with theme context 1`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -27481,7 +26414,6 @@ exports[`Icon with theme context 1`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <div>
@@ -27537,7 +26469,6 @@ exports[`Icon with theme props 1`] = `
 .c0 *[stroke*="#"],
 .c0 *[STROKE*="#"] {
   stroke: inherit;
-  fill: none;
 }
 
 .c0 *[fill-rule],
@@ -27545,7 +26476,6 @@ exports[`Icon with theme props 1`] = `
 .c0 *[fill*="#"],
 .c0 *[FILL*="#"] {
   fill: inherit;
-  stroke: none;
 }
 
 <svg


### PR DESCRIPTION
Fix for StyledIcon setting both fill and stroke styles, example:
```
<ZoomOut theme={{icon: {extend: css`
       ${props => `
         fill: black;
         stroke: red;
       ` }
     `},}}/>
```