### PR TITLE
Styled components CHANNEL deprecated fix

### DIFF
--- a/src/js/Icon.js
+++ b/src/js/Icon.js
@@ -19,21 +19,21 @@ class Icon extends Component {
     theme: undefined,
   };
 
-  unsubscribeId: -1;
+  scSubscriptionId: undefined;
 
   componentWillMount() {
     const styledContext = this.context[CHANNEL_NEXT];
-    if (styledContext !== undefined) {
+    if (styledContext) {
       const { subscribe } = styledContext;
-      this.unsubscriberId = subscribe(theme => this.setState({ theme }));
+      this.scSubscriptionId = subscribe(theme => this.setState({ theme }));
     }
   }
 
   componentWillUnmount() {
     const styledContext = this.context[CHANNEL_NEXT];
-    if (styledContext !== undefined && this.unsubscribeId !== -1) {
+    if (this.scSubscriptionId) {
       const { unsubscribe } = styledContext;
-      unsubscribe(this.unsubscribeId);
+      unsubscribe(this.scSubscriptionId);
     }
   }
 

--- a/src/js/Icon.js
+++ b/src/js/Icon.js
@@ -1,7 +1,10 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import deepAssign from 'deep-assign';
-import { CHANNEL } from 'styled-components/lib/models/ThemeProvider';
+import {
+  CHANNEL_NEXT,
+  CONTEXT_CHANNEL_SHAPE,
+} from 'styled-components/lib/models/ThemeProvider';
 
 import StyledIcon from './StyledIcon';
 
@@ -9,23 +12,28 @@ class Icon extends Component {
   static contextTypes = {
     grommet: PropTypes.object,
     theme: PropTypes.object,
-    [CHANNEL]: PropTypes.func,
+    [CHANNEL_NEXT]: CONTEXT_CHANNEL_SHAPE,
   };
 
   state = {
     theme: undefined,
   };
 
+  unsubscribeId: -1;
+
   componentWillMount() {
-    const subscribe = this.context[CHANNEL];
-    if (typeof subscribe === 'function') {
-      this.unsubscribe = subscribe(theme => this.setState({ theme }));
+    const styledContext = this.context[CHANNEL_NEXT];
+    if (styledContext !== undefined) {
+      const { subscribe } = styledContext;
+      this.unsubscriberId = subscribe(theme => this.setState({ theme }));
     }
   }
 
   componentWillUnmount() {
-    if (typeof this.unsubscribe === 'function') {
-      this.unsubscribe();
+    const styledContext = this.context[CHANNEL_NEXT];
+    if (styledContext !== undefined && this.unsubscribeId !== -1) {
+      const { unsubscribe } = styledContext;
+      unsubscribe(this.unsubscribeId);
     }
   }
 


### PR DESCRIPTION
Hello. 

Styled component's CHANNEL is deprecated. This is generating a warning like this one:

```Warning: Usage of `context.__styled-components__` as a function is deprecated. It will be replaced with the object on `.context.__styled-components__next__` in a future version.```

This PR migrates the code to CHANNEL_NEXT.