### PR TITLE
add correct theme reference for icon size

### DIFF
--- a/src/js/StyledIcon.js
+++ b/src/js/StyledIcon.js
@@ -45,11 +45,11 @@ const StyledIcon = styled(IconInner)`
   flex: 0 0 auto;
 
   ${({ size = 'medium', theme }) => `
-    width: ${theme.icon.size[size] || size};
-    height: ${theme.icon.size[size] || size};
+    width: ${theme.global.icon.size[size] || size};
+    height: ${theme.global.icon.size[size] || size};
   `}
   ${({ color }) => color !== 'plain' && colorCss}
-  ${({ theme }) => theme && theme.icon.extend}
+  ${({ theme }) => theme && theme.global.icon.extend}
 `;
 
 StyledIcon.defaultProps = {};

--- a/src/js/__tests__/Icon-test.js
+++ b/src/js/__tests__/Icon-test.js
@@ -61,11 +61,13 @@ test('Icon with ThemeProvider', () => {
           colors: {
             icon: '#888888',
           },
-        },
-        icon: {
-          size: {
-            large: '24px',
-            xlarge: '112px',
+          icon: {
+            size: {
+              xsmall: '8px',
+              large: '24px',
+              xlarge: '112px',
+            },
+            extend: () => {},
           },
         },
       }}

--- a/src/js/__tests__/__snapshots__/Components-test.js.snap
+++ b/src/js/__tests__/__snapshots__/Components-test.js.snap
@@ -562,13 +562,13 @@ Object {
       "colors": Object {
         "icon": "#666666",
       },
-    },
-    "icon": Object {
-      "size": Object {
-        "large": "48px",
-        "medium": "24px",
-        "small": "12px",
-        "xlarge": "96px",
+      "icon": Object {
+        "size": Object {
+          "large": "48px",
+          "medium": "24px",
+          "small": "12px",
+          "xlarge": "96px",
+        },
       },
     },
   },
@@ -578,13 +578,13 @@ Object {
         "colors": Object {
           "icon": "#666666",
         },
-      },
-      "icon": Object {
-        "size": Object {
-          "large": "48px",
-          "medium": "24px",
-          "small": "12px",
-          "xlarge": "96px",
+        "icon": Object {
+          "size": Object {
+            "large": "48px",
+            "medium": "24px",
+            "small": "12px",
+            "xlarge": "96px",
+          },
         },
       },
     },

--- a/src/js/icon.stories.js
+++ b/src/js/icon.stories.js
@@ -11,13 +11,13 @@ const customTheme = {
       icon: '#2196f3',
       attention: '#ff3333',
     },
-  },
-  icon: {
-    size: {
-      small: '12px',
-      medium: '24px',
-      large: '48px',
-      xlarge: '300px',
+    icon: {
+      size: {
+        small: '12px',
+        medium: '24px',
+        large: '48px',
+        xlarge: '300px',
+      },
     },
   },
 };

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -3,13 +3,14 @@ export const base = {
     colors: {
       icon: '#666666',
     },
-  },
-  icon: {
-    size: {
-      small: '12px',
-      medium: '24px',
-      large: '48px',
-      xlarge: '96px',
+    icon: {
+      size: {
+        small: '12px',
+        medium: '24px',
+        large: '48px',
+        xlarge: '96px',
+      },
     },
+    // extend: undefined,
   },
 };


### PR DESCRIPTION
Fixes: https://github.com/grommet/grommet/issues/2971
Uses the correct base.js structure as specified on https://github.com/grommet/grommet-icons README