### PR TITLE
🚑 (Metadata) Fix typo in metadata look up: s/ApppleAppStore/AppleAppStore

### DIFF
--- a/src/js/__tests__/__snapshots__/metadata-test.js.snap
+++ b/src/js/__tests__/__snapshots__/metadata-test.js.snap
@@ -142,7 +142,7 @@ Object {
     "mac",
     "macbook",
   ],
-  "ApppleAppStore": Array [
+  "AppleAppStore": Array [
     "donglebook",
     "iphone",
     "imac",

--- a/src/js/metadata.js
+++ b/src/js/metadata.js
@@ -18,7 +18,7 @@ export default {
   'Android': ['cyborg', 'droid', 'humanoid', 'mobile', 'os', 'phone', 'robot', 'smartphone'],
   'Announce': ['bullhorn', 'loud', 'speaker', 'megaphone'],
   'Apple': ['donglebook', 'iphone', 'imac', 'logo', 'mac', 'macbook'],
-  'ApppleAppStore': ['donglebook', 'iphone', 'imac', 'logo', 'mac', 'macbook', 'store'],
+  'AppleAppStore': ['donglebook', 'iphone', 'imac', 'logo', 'mac', 'macbook', 'store'],
   'Apps': ['grid', 'menu'],
   'Archive': ['backup', 'box', 'container', 'document', 'files', 'folder', 'storage'],
   'Archlinux': ['linux', 'logo', 'os'],


### PR DESCRIPTION
This fixes #138