### PR TITLE
Deploy storybook for grommet-icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ yarn-error.log
 .tmp/
 icons.md
 package-lock.json
+storybook-static

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  command = "yarn build-storybook"
+  publish = "storybook-static"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "release-stable": "babel-node ./tools/release-stable",
     "lint": "eslint src",
     "storybook": "start-storybook -p 9002 -c storybook",
+    "build-storybook": "build-storybook -c storybook -o storybook-static -s ./storybook/public",
     "test": "jest",
     "test-update": "jest --updateSnapshot",
     "test-watch": "jest --watchAll"

--- a/src/js/icon.stories.js
+++ b/src/js/icon.stories.js
@@ -54,46 +54,4 @@ storiesOf('Icon', module)
         <Icon size={text('Size', 'xlarge')} />
       </ThemeProvider>
     );
-  })
-  .add('Js', () => {
-    const Icon = Icons[text('Icon', 'Js')];
-    if (!Icon) {
-      return null;
-    }
-    return <><Icon /><Icon color='plain' /></>;
-  })
-  .add('WifiNone', () => {
-    const Icon = Icons[text('Icon', 'WifiNone')];
-    if (!Icon) {
-      return null;
-    }
-    return <><Icon /><Icon color='plain' /></>;
-  })
-  .add('WifiMedium', () => {
-    const Icon = Icons[text('Icon', 'WifiMedium')];
-    if (!Icon) {
-      return null;
-    }
-    return <><Icon /><Icon color='plain' /></>;
-  })
-  .add('Coffee', () => {
-    const Icon = Icons[text('Icon', 'Coffee')];
-    if (!Icon) {
-      return null;
-    }
-    return <><Icon /><Icon color='plain' /></>;
-  })
-  .add('Amazon', () => {
-    const Icon = Icons[text('Icon', 'Amazon')];
-    if (!Icon) {
-      return null;
-    }
-    return <><Icon /><Icon color='plain' /></>;
-  })
-  .add('GooglePlay', () => {
-    const Icon = Icons[text('Icon', 'GooglePlay')];
-    if (!Icon) {
-      return null;
-    }
-    return <><Icon /><Icon color='plain' /></>;
   });


### PR DESCRIPTION
Allowing Netlify to deploy storybook for grommet-icons.
Cleaning up storybook examples.

It works, see Netlify deployment below https://deploy-preview-181--hungry-raman-b31556.netlify.app/?selectedKind=Icon&selectedStory=Default&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs