### PR TITLE
FormAttachment metadata update

### DIFF
--- a/src/js/__tests__/__snapshots__/metadata-test.js.snap
+++ b/src/js/__tests__/__snapshots__/metadata-test.js.snap
@@ -1433,6 +1433,7 @@ Object {
     "plus",
   ],
   "FormAttachment": Array [
+    "attachment",
     "attach",
     "clip",
     "files",

--- a/src/js/metadata.js
+++ b/src/js/metadata.js
@@ -223,7 +223,7 @@ export default {
   'FolderCycle': ['documents', 'data', 'files', 'recycle', 'refresh'],
   'FolderOpen': ['documents', 'data', 'files'],
   'FormAdd': ['create', 'form', 'increase', 'increment', 'new', 'plus'],
-  'FormAttachment': ['attach', 'clip', 'files', 'form', 'paper', 'upload'],
+  'FormAttachment': ['attachment','attach', 'clip', 'files', 'form', 'paper', 'upload'],
   'FormCalendar': ['date', 'day', 'event', 'form', 'month', 'schedule', 'year'],
   'FormCheckmark': ['accept', 'agree', 'done', 'form', 'good', 'ok'],
   'FormClock': ['alarm', 'form', 'hour', 'minute', 'second', 'time', 'timer', 'watch'],


### PR DESCRIPTION
**What does this PR do?**

- Resolves one task under https://github.com/grommet/hpe-design-system/issues/1957#issuecomment-1190447427
- Updated the `FormAttachment` metadata to include the word `"attachment"`


**What testing has been done on this PR?**
Basic Snapshot testing present in the repo

