### PR TITLE
Add util function to match icon height with line-height if specified

### DIFF
--- a/src/js/StyledIcon.js
+++ b/src/js/StyledIcon.js
@@ -4,7 +4,7 @@ import styled, { css } from 'styled-components';
 import { colorStyle } from 'grommet-styles';
 
 import { defaultProps } from './default-props';
-import { parseMetricToNum, useIconPad } from './utils';
+import { iconPad, parseMetricToNum } from './utils';
 
 const colorCss = css`
   ${(props) =>
@@ -80,7 +80,7 @@ const StyledIcon = styled(IconInner)`
     `;
   }}
   ${({ color }) => color !== 'plain' && colorCss}
-  ${(props) => useIconPad(props)}
+  ${(props) => props.height && iconPad(props)}
   ${({ theme }) => theme && theme.icon.extend}
 `;
 

--- a/src/js/StyledIcon.js
+++ b/src/js/StyledIcon.js
@@ -4,15 +4,17 @@ import styled, { css } from 'styled-components';
 import { colorStyle } from 'grommet-styles';
 
 import { defaultProps } from './default-props';
-import { parseMetricToNum } from './utils';
+import { parseMetricToNum, useIconPad } from './utils';
 
 const colorCss = css`
-  ${(props) => colorStyle(
+  ${(props) =>
+    colorStyle(
       'fill',
       props.color || props.theme.global.colors.icon,
       props.theme,
     )}
-  ${(props) => colorStyle(
+  ${(props) =>
+    colorStyle(
       'stroke',
       props.color || props.theme.global.colors.icon,
       props.theme,
@@ -24,31 +26,29 @@ const colorCss = css`
   }
 
   *:not([stroke]) {
-    &[fill="none"] {
+    &[fill='none'] {
       stroke-width: 0;
     }
   }
 
-  *[stroke*="#"],
-  *[STROKE*="#"] {
+  *[stroke*='#'],
+  *[STROKE*='#'] {
     stroke: inherit;
     fill: none;
   }
 
   *[fill-rule],
   *[FILL-RULE],
-  *[fill*="#"],
-  *[FILL*="#"] {
+  *[fill*='#'],
+  *[FILL*='#'] {
     fill: inherit;
     stroke: none;
   }
 `;
 
 const IconInner = forwardRef(
-  ({
- a11yTitle, color, size, theme, ...rest
-}, ref) => (
-  <svg ref={ref} aria-label={a11yTitle} {...rest} />
+  ({ a11yTitle, color, size, theme, ...rest }, ref) => (
+    <svg ref={ref} aria-label={a11yTitle} {...rest} />
   ),
 );
 IconInner.displayName = 'Icon';
@@ -80,6 +80,7 @@ const StyledIcon = styled(IconInner)`
     `;
   }}
   ${({ color }) => color !== 'plain' && colorCss}
+  ${(props) => useIconPad(props)}
   ${({ theme }) => theme && theme.icon.extend}
 `;
 

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -11,5 +11,11 @@ export const base = {
       large: '48px',
       xlarge: '96px',
     },
+    // height: {
+    //   small: undefined,
+    //   medium: undefined,
+    //   large: undefined,
+    //   xlarge: undefined,
+    // },
   },
 };

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -11,11 +11,5 @@ export const base = {
       large: '48px',
       xlarge: '96px',
     },
-    // height: {
-    //   small: undefined,
-    //   medium: undefined,
-    //   large: undefined,
-    //   xlarge: undefined,
-    // },
   },
 };

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -47,17 +47,17 @@ export function useScaleProps(props) {
 
 // iconPad applies top/bottom padding to icon to ensure it aligns
 // with text line-height
-export function useIconPad(props) {
-  const { size = 'medium' } = props;
+export function iconPad(props) {
+  const { height, size = 'medium' } = props;
   const theme = useContext(ThemeContext);
 
   let style = '';
-  if (theme?.icon?.height?.[size]) {
-    const dimension = parseMetricToNum(theme.icon.size[size] || size);
-    const height = parseMetricToNum(theme.icon.height[size]);
+  if (theme?.text?.[height]?.height) {
+    const dimension = parseMetricToNum(theme.icon?.size?.[size] || size);
+    const lineHeight = parseMetricToNum(theme?.text?.[height]?.height);
 
-    if (height > dimension) {
-      const pad = `${(height - dimension) / 2}px`;
+    if (lineHeight > dimension) {
+      const pad = `${(lineHeight - dimension) / 2}px`;
       style += `padding-top: ${pad}; padding-bottom: ${pad};`;
     }
   }
@@ -69,6 +69,6 @@ export default {
   deepMerge,
   isObject,
   parseMetricToNum,
-  useIconPad,
+  iconPad,
   useScaleProps,
 };

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -45,4 +45,30 @@ export function useScaleProps(props) {
   return result;
 }
 
-export default { deepMerge, isObject, parseMetricToNum, useScaleProps };
+// iconPad applies top/bottom padding to icon to ensure it aligns
+// with text line-height
+export function useIconPad(props) {
+  const { size = 'medium' } = props;
+  const theme = useContext(ThemeContext);
+
+  let style = '';
+  if (theme?.icon?.height?.[size]) {
+    const dimension = parseMetricToNum(theme.icon.size[size] || size);
+    const height = parseMetricToNum(theme.icon.height[size]);
+
+    if (height > dimension) {
+      const pad = `${(height - dimension) / 2}px`;
+      style += `padding-top: ${pad}; padding-bottom: ${pad};`;
+    }
+  }
+
+  return style;
+}
+
+export default {
+  deepMerge,
+  isObject,
+  parseMetricToNum,
+  useIconPad,
+  useScaleProps,
+};


### PR DESCRIPTION
Adds utility function that can key off of line-height of theme text sizes as a means of adding top/bottom pad to the svg. In themes where the icon size is smaller than text line height, this can cause mis-alignments of icons with text -- especially noticeable in cases where icons and text are aligned in a row with align="start".

This util function calculates the difference between the desired height (line height) and icon dimension and applies half as pad to the top and half as pad to the bottom. Callers would be required to add `height="medium"` to an icon in a case where they have an icon in a row with medium sized text that is aligned to the start.

For all Grommet component instances (like Notification), this will be handled for the caller.

## Chrome

BEFORE
<img width="174" alt="Screen Shot 2023-02-28 at 12 22 46 PM" src="https://user-images.githubusercontent.com/12522275/221995834-3106943e-a7cb-4d82-9a6a-5e0fef23b502.png">

AFTER
<img width="148" alt="Screen Shot 2023-02-28 at 12 23 16 PM" src="https://user-images.githubusercontent.com/12522275/221995819-170151eb-1e75-42d8-a782-44ed64ffe9c6.png">

<img width="169" alt="Screen Shot 2023-02-28 at 12 24 56 PM" src="https://user-images.githubusercontent.com/12522275/221996054-35e41a83-7e47-4f5d-bd9d-ef729c1fab81.png">

![localhost_9002_iframe html_knob-Icon=LinkNext args= id=icon--height viewMode=story (1)](https://user-images.githubusercontent.com/12522275/222283050-e2cf4dfa-856f-435d-a5f6-ae4b060b4acf.png)

## Safari

BEFORE
<img width="154" alt="Screen Shot 2023-02-28 at 12 23 00 PM" src="https://user-images.githubusercontent.com/12522275/221995831-950a5921-fe38-41fd-bb93-94224eb8ad72.png">

AFTER
<img width="155" alt="Screen Shot 2023-02-28 at 12 23 11 PM" src="https://user-images.githubusercontent.com/12522275/221995828-486f96c0-1c1c-4bc4-a759-8ad79a20469f.png">




