### PR TITLE
Remove height from DOM

### DIFF
--- a/src/js/StyledIcon.js
+++ b/src/js/StyledIcon.js
@@ -51,7 +51,12 @@ const IconInner = forwardRef(
 );
 IconInner.displayName = 'Icon';
 
-const StyledIcon = styled(IconInner)`
+const StyledIcon = styled(IconInner).withConfig({
+  // don't let height attribute leak to DOM
+  // https://styled-components.com/docs/api#shouldforwardprop
+  shouldForwardProp: (prop) =>
+    !['height'].includes(prop), 
+})`
   display: inline-block;
   flex: 0 0 auto;
 


### PR DESCRIPTION
Don't let height prop leak through to DOM. Following pattern used in Grommet.