### PR TITLE
Remove grommet-styles package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Slack](http://alansouzati.github.io/artic/img/slack-badge.svg)](http://slackin.grommet.io)  [![Build Status](https://travis-ci.org/grommet/grommet-icons.svg?branch=master)](https://travis-ci.org/grommet/grommet-icons) [![Test Coverage](https://codeclimate.com/github/grommet/grommet-icons/badges/coverage.svg)](https://codeclimate.com/github/grommet/grommet-icons/coverage)  [![Dependency Status](https://david-dm.org/grommet/grommet-icons.svg)](https://david-dm.org/grommet/grommet-icons) [![PRs Welcome](https://img.shields.io/badge/pr's-welcome-7d4cdb.svg)][contributing]
+[![Slack](http://alansouzati.github.io/artic/img/slack-badge.svg)](http://slackin.grommet.io) [![Build Status](https://travis-ci.org/grommet/grommet-icons.svg?branch=master)](https://travis-ci.org/grommet/grommet-icons) [![Test Coverage](https://codeclimate.com/github/grommet/grommet-icons/badges/coverage.svg)](https://codeclimate.com/github/grommet/grommet-icons/coverage) [![Dependency Status](https://david-dm.org/grommet/grommet-icons.svg)](https://david-dm.org/grommet/grommet-icons) [![PRs Welcome](https://img.shields.io/badge/pr's-welcome-7d4cdb.svg)][contributing]
 
 # grommet-icons
 
@@ -6,11 +6,11 @@ Iconography for Grommet and React.js
 
 ## Install
 
-`npm install grommet-icons grommet-styles --save`
+`npm install grommet-icons --save`
 
 or
 
-`yarn add grommet-icons grommet-styles`
+`yarn add grommet-icons`
 
 ## Usage
 
@@ -26,16 +26,21 @@ import { Facebook } from 'grommet-icons';
 Visit our [site](https://icons.grommet.io/) for more icons.
 
 ## Create Your Own Grommet Icon
+
 Any 24x24px SVG may be converted to an icon using the `<Blank>` icon. For example:
 
 ```javascript
 import React from 'react';
 import { Blank } from 'grommet-icons';
 
-export const MyIcon = props => (
+export const MyIcon = (props) => (
   <Blank {...props}>
     {/* your 24x24 svg goes here - e.g. here's a 24x24px circle */}
-    <svg viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+    <svg
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      xmlns="http://www.w3.org/2000/svg"
+    >
       <circle cx="12" cy="12" r="5" />
     </svg>
   </Blank>
@@ -75,40 +80,40 @@ instance: `colors: { brand: '#ff0000' }` would allow you to use
 `<ZoomOut color='brand' />`.
 
 ```javascript
-  import { ThemeProvider } from 'styled-components';
-  import { base, deepMerge } from 'grommet-icons';
-  const theme = deepMerge(base, {
-    global: {
-      colors: {
-        brand: '#ff0000',
-      },
+import { ThemeProvider } from 'styled-components';
+import { base, deepMerge } from 'grommet-icons';
+const theme = deepMerge(base, {
+  global: {
+    colors: {
+      brand: '#ff0000',
     },
-  });
-  return (
-    <ThemeContext.Provider theme={theme}>
-      <ZoomOut color='brand' />
-    </ThemeContext.Provider>
-  );
+  },
+});
+return (
+  <ThemeContext.Provider theme={theme}>
+    <ZoomOut color="brand" />
+  </ThemeContext.Provider>
+);
 ```
 
 ## Build
 
 To build this library, execute the following commands:
 
-  1. Install NPM modules
+1. Install NPM modules
 
-    $ npm install (or yarn install)
+   $ npm install (or yarn install)
 
-  2. Run pack
+2. Run pack
 
-    $ npm run build
+   $ npm run build
 
-  3. Test and run linters:
+3. Test and run linters:
 
-    $ npm run lint
+   $ npm run lint
 
-  4. Generate React icons:
+4. Generate React icons:
 
-    $ npm run generate-icons
+   $ npm run generate-icons
 
 [contributing]: CONTRIBUTING.md

--- a/package.json
+++ b/package.json
@@ -37,9 +37,6 @@
     "react-dom": "^16.6.0 || ^17.0.0 || ^18.0.0",
     "styled-components": ">= 5.x"
   },
-  "dependencies": {
-    "grommet-styles": "^0.2.0"
-  },
   "devDependencies": {
     "@babel/cli": "^7.1.2",
     "@babel/core": "^7.17.9",
@@ -78,7 +75,6 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.9.1",
     "fs-extra": "^11.1.0",
-    "grommet-styles": "^0.2.0",
     "jest-cli": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
     "jest-styled-components": "^7.0.0",

--- a/src/js/StyledIcon.js
+++ b/src/js/StyledIcon.js
@@ -1,18 +1,53 @@
 import React, { forwardRef } from 'react';
 import styled, { css } from 'styled-components';
 
-import { colorStyle } from 'grommet-styles';
-
 import { defaultProps } from './default-props';
 import { iconPad, parseMetricToNum } from './utils';
 
+// Returns the specific color that should be used according to the theme.
+// If 'dark' is supplied, it takes precedence over 'theme.dark'.
+// Can return undefined.
+const normalizeColor = (color, theme, dark) => {
+  const colorSpec =
+    theme.global && theme.global.colors[color] !== undefined
+      ? theme.global.colors[color]
+      : color;
+  // If the color has a light or dark object, use that
+  let result = colorSpec;
+  if (colorSpec) {
+    if (
+      (dark === true || (dark === undefined && theme.dark)) &&
+      colorSpec.dark !== undefined
+    ) {
+      result = colorSpec.dark;
+    } else if (
+      (dark === false || !theme.dark) &&
+      colorSpec.light !== undefined
+    ) {
+      result = colorSpec.light;
+    }
+  }
+  // allow one level of indirection in color names
+  if (result && theme.global && theme.global.colors[result] !== undefined) {
+    result = normalizeColor(result, theme, dark);
+  }
+
+  return result;
+};
+
+const colorStyle = (name, value, theme, required) => css`
+  ${name}: ${normalizeColor(value, theme, required)};
+`;
+
 const colorCss = css`
-  ${(props) => colorStyle(
+  ${(props) =>
+    colorStyle(
       'fill',
       props.color || props.theme.global.colors.icon,
       props.theme,
     )}
-  ${(props) => colorStyle(
+  ${(props) =>
+    colorStyle(
       'stroke',
       props.color || props.theme.global.colors.icon,
       props.theme,
@@ -24,21 +59,21 @@ const colorCss = css`
   }
 
   *:not([stroke]) {
-    &[fill="none"] {
+    &[fill='none'] {
       stroke-width: 0;
     }
   }
 
-  *[stroke*="#"],
-  *[STROKE*="#"] {
+  *[stroke*='#'],
+  *[STROKE*='#'] {
     stroke: inherit;
     fill: none;
   }
 
   *[fill-rule],
   *[FILL-RULE],
-  *[fill*="#"],
-  *[FILL*="#"] {
+  *[fill*='#'],
+  *[FILL*='#'] {
     fill: inherit;
     stroke: none;
   }
@@ -54,8 +89,7 @@ IconInner.displayName = 'Icon';
 const StyledIcon = styled(IconInner).withConfig({
   // don't let height attribute leak to DOM
   // https://styled-components.com/docs/api#shouldforwardprop
-  shouldForwardProp: (prop) =>
-    !['height', 'width'].includes(prop), 
+  shouldForwardProp: (prop) => !['height', 'width'].includes(prop),
 })`
   display: inline-block;
   flex: 0 0 auto;

--- a/src/js/__tests__/__snapshots__/Icon-test.js.snap
+++ b/src/js/__tests__/__snapshots__/Icon-test.js.snap
@@ -17,20 +17,20 @@ exports[`Icon Blank 1`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -59,20 +59,20 @@ exports[`Icon ThemeProvider 1`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -114,20 +114,20 @@ exports[`Icon all icons 1`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -179,20 +179,20 @@ exports[`Icon all icons 2`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -230,20 +230,20 @@ exports[`Icon all icons 3`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -279,20 +279,20 @@ exports[`Icon all icons 4`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -328,20 +328,20 @@ exports[`Icon all icons 5`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -377,20 +377,20 @@ exports[`Icon all icons 6`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -428,20 +428,20 @@ exports[`Icon all icons 7`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -477,20 +477,20 @@ exports[`Icon all icons 8`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -526,20 +526,20 @@ exports[`Icon all icons 9`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -575,20 +575,20 @@ exports[`Icon all icons 10`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -624,20 +624,20 @@ exports[`Icon all icons 11`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -673,20 +673,20 @@ exports[`Icon all icons 12`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -722,20 +722,20 @@ exports[`Icon all icons 13`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -771,20 +771,20 @@ exports[`Icon all icons 14`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -820,20 +820,20 @@ exports[`Icon all icons 15`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -868,20 +868,20 @@ exports[`Icon all icons 16`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -916,20 +916,20 @@ exports[`Icon all icons 17`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -965,20 +965,20 @@ exports[`Icon all icons 18`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -1014,20 +1014,20 @@ exports[`Icon all icons 19`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -1062,20 +1062,20 @@ exports[`Icon all icons 20`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -1111,20 +1111,20 @@ exports[`Icon all icons 21`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -1158,20 +1158,20 @@ exports[`Icon all icons 22`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -1206,20 +1206,20 @@ exports[`Icon all icons 23`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -1255,20 +1255,20 @@ exports[`Icon all icons 24`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -1304,20 +1304,20 @@ exports[`Icon all icons 25`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -1353,20 +1353,20 @@ exports[`Icon all icons 26`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -1401,20 +1401,20 @@ exports[`Icon all icons 27`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -1450,20 +1450,20 @@ exports[`Icon all icons 28`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -1498,20 +1498,20 @@ exports[`Icon all icons 29`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -1547,20 +1547,20 @@ exports[`Icon all icons 30`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -1596,20 +1596,20 @@ exports[`Icon all icons 31`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -1647,20 +1647,20 @@ exports[`Icon all icons 32`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -1696,20 +1696,20 @@ exports[`Icon all icons 33`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -1745,20 +1745,20 @@ exports[`Icon all icons 34`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -1794,20 +1794,20 @@ exports[`Icon all icons 35`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -1845,20 +1845,20 @@ exports[`Icon all icons 36`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -1894,20 +1894,20 @@ exports[`Icon all icons 37`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -1943,20 +1943,20 @@ exports[`Icon all icons 38`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -1992,20 +1992,20 @@ exports[`Icon all icons 39`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -2041,20 +2041,20 @@ exports[`Icon all icons 40`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -2089,20 +2089,20 @@ exports[`Icon all icons 41`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -2138,20 +2138,20 @@ exports[`Icon all icons 42`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -2186,20 +2186,20 @@ exports[`Icon all icons 43`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -2235,20 +2235,20 @@ exports[`Icon all icons 44`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -2284,20 +2284,20 @@ exports[`Icon all icons 45`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -2330,20 +2330,20 @@ exports[`Icon all icons 46`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -2379,20 +2379,20 @@ exports[`Icon all icons 47`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -2428,20 +2428,20 @@ exports[`Icon all icons 48`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -2474,20 +2474,20 @@ exports[`Icon all icons 49`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -2523,20 +2523,20 @@ exports[`Icon all icons 50`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -2572,20 +2572,20 @@ exports[`Icon all icons 51`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -2621,20 +2621,20 @@ exports[`Icon all icons 52`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -2670,20 +2670,20 @@ exports[`Icon all icons 53`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -2719,20 +2719,20 @@ exports[`Icon all icons 54`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -2768,20 +2768,20 @@ exports[`Icon all icons 55`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -2817,20 +2817,20 @@ exports[`Icon all icons 56`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -2866,20 +2866,20 @@ exports[`Icon all icons 57`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -2915,20 +2915,20 @@ exports[`Icon all icons 58`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -2964,20 +2964,20 @@ exports[`Icon all icons 59`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -3013,20 +3013,20 @@ exports[`Icon all icons 60`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -3062,20 +3062,20 @@ exports[`Icon all icons 61`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -3111,20 +3111,20 @@ exports[`Icon all icons 62`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -3160,20 +3160,20 @@ exports[`Icon all icons 63`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -3209,20 +3209,20 @@ exports[`Icon all icons 64`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -3259,20 +3259,20 @@ exports[`Icon all icons 65`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -3308,20 +3308,20 @@ exports[`Icon all icons 66`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -3355,20 +3355,20 @@ exports[`Icon all icons 67`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -3404,20 +3404,20 @@ exports[`Icon all icons 68`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -3451,20 +3451,20 @@ exports[`Icon all icons 69`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -3500,20 +3500,20 @@ exports[`Icon all icons 70`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -3549,20 +3549,20 @@ exports[`Icon all icons 71`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -3596,20 +3596,20 @@ exports[`Icon all icons 72`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -3643,20 +3643,20 @@ exports[`Icon all icons 73`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -3692,20 +3692,20 @@ exports[`Icon all icons 74`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -3741,20 +3741,20 @@ exports[`Icon all icons 75`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -3790,20 +3790,20 @@ exports[`Icon all icons 76`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -3839,20 +3839,20 @@ exports[`Icon all icons 77`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -3887,20 +3887,20 @@ exports[`Icon all icons 78`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -3936,20 +3936,20 @@ exports[`Icon all icons 79`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -3985,20 +3985,20 @@ exports[`Icon all icons 80`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -4034,20 +4034,20 @@ exports[`Icon all icons 81`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -4083,20 +4083,20 @@ exports[`Icon all icons 82`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -4132,20 +4132,20 @@ exports[`Icon all icons 83`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -4181,20 +4181,20 @@ exports[`Icon all icons 84`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -4230,20 +4230,20 @@ exports[`Icon all icons 85`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -4279,20 +4279,20 @@ exports[`Icon all icons 86`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -4328,20 +4328,20 @@ exports[`Icon all icons 87`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -4377,20 +4377,20 @@ exports[`Icon all icons 88`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -4441,20 +4441,20 @@ exports[`Icon all icons 89`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -4490,20 +4490,20 @@ exports[`Icon all icons 90`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -4539,20 +4539,20 @@ exports[`Icon all icons 91`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -4588,20 +4588,20 @@ exports[`Icon all icons 92`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -4637,20 +4637,20 @@ exports[`Icon all icons 93`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -4686,20 +4686,20 @@ exports[`Icon all icons 94`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -4735,20 +4735,20 @@ exports[`Icon all icons 95`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -4784,20 +4784,20 @@ exports[`Icon all icons 96`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -4833,20 +4833,20 @@ exports[`Icon all icons 97`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -4886,20 +4886,20 @@ exports[`Icon all icons 98`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -4935,20 +4935,20 @@ exports[`Icon all icons 99`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -4984,20 +4984,20 @@ exports[`Icon all icons 100`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -5033,20 +5033,20 @@ exports[`Icon all icons 101`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -5082,20 +5082,20 @@ exports[`Icon all icons 102`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -5131,20 +5131,20 @@ exports[`Icon all icons 103`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -5180,20 +5180,20 @@ exports[`Icon all icons 104`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -5229,20 +5229,20 @@ exports[`Icon all icons 105`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -5278,20 +5278,20 @@ exports[`Icon all icons 106`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -5326,20 +5326,20 @@ exports[`Icon all icons 107`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -5375,20 +5375,20 @@ exports[`Icon all icons 108`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -5426,20 +5426,20 @@ exports[`Icon all icons 109`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -5475,20 +5475,20 @@ exports[`Icon all icons 110`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -5524,20 +5524,20 @@ exports[`Icon all icons 111`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -5572,20 +5572,20 @@ exports[`Icon all icons 112`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -5628,20 +5628,20 @@ exports[`Icon all icons 113`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -5677,20 +5677,20 @@ exports[`Icon all icons 114`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -5726,20 +5726,20 @@ exports[`Icon all icons 115`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -5775,20 +5775,20 @@ exports[`Icon all icons 116`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -5824,20 +5824,20 @@ exports[`Icon all icons 117`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -5873,20 +5873,20 @@ exports[`Icon all icons 118`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -5922,20 +5922,20 @@ exports[`Icon all icons 119`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -5971,20 +5971,20 @@ exports[`Icon all icons 120`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -6022,20 +6022,20 @@ exports[`Icon all icons 121`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -6069,20 +6069,20 @@ exports[`Icon all icons 122`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -6118,20 +6118,20 @@ exports[`Icon all icons 123`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -6167,20 +6167,20 @@ exports[`Icon all icons 124`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -6216,20 +6216,20 @@ exports[`Icon all icons 125`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -6265,20 +6265,20 @@ exports[`Icon all icons 126`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -6314,20 +6314,20 @@ exports[`Icon all icons 127`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -6362,20 +6362,20 @@ exports[`Icon all icons 128`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -6411,20 +6411,20 @@ exports[`Icon all icons 129`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -6462,20 +6462,20 @@ exports[`Icon all icons 130`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -6511,20 +6511,20 @@ exports[`Icon all icons 131`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -6560,20 +6560,20 @@ exports[`Icon all icons 132`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -6609,20 +6609,20 @@ exports[`Icon all icons 133`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -6658,20 +6658,20 @@ exports[`Icon all icons 134`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -6707,20 +6707,20 @@ exports[`Icon all icons 135`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -6756,20 +6756,20 @@ exports[`Icon all icons 136`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -6805,20 +6805,20 @@ exports[`Icon all icons 137`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -6854,20 +6854,20 @@ exports[`Icon all icons 138`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -6902,20 +6902,20 @@ exports[`Icon all icons 139`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -6951,20 +6951,20 @@ exports[`Icon all icons 140`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -7000,20 +7000,20 @@ exports[`Icon all icons 141`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -7049,20 +7049,20 @@ exports[`Icon all icons 142`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -7098,20 +7098,20 @@ exports[`Icon all icons 143`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -7147,20 +7147,20 @@ exports[`Icon all icons 144`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -7196,20 +7196,20 @@ exports[`Icon all icons 145`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -7247,20 +7247,20 @@ exports[`Icon all icons 146`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -7296,20 +7296,20 @@ exports[`Icon all icons 147`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -7345,20 +7345,20 @@ exports[`Icon all icons 148`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -7394,20 +7394,20 @@ exports[`Icon all icons 149`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -7443,20 +7443,20 @@ exports[`Icon all icons 150`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -7492,20 +7492,20 @@ exports[`Icon all icons 151`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -7542,20 +7542,20 @@ exports[`Icon all icons 152`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -7590,20 +7590,20 @@ exports[`Icon all icons 153`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -7639,20 +7639,20 @@ exports[`Icon all icons 154`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -7688,20 +7688,20 @@ exports[`Icon all icons 155`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -7737,20 +7737,20 @@ exports[`Icon all icons 156`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -7786,20 +7786,20 @@ exports[`Icon all icons 157`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -7835,20 +7835,20 @@ exports[`Icon all icons 158`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -7884,20 +7884,20 @@ exports[`Icon all icons 159`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -7933,20 +7933,20 @@ exports[`Icon all icons 160`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -7982,20 +7982,20 @@ exports[`Icon all icons 161`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -8031,20 +8031,20 @@ exports[`Icon all icons 162`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -8080,20 +8080,20 @@ exports[`Icon all icons 163`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -8129,20 +8129,20 @@ exports[`Icon all icons 164`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -8178,20 +8178,20 @@ exports[`Icon all icons 165`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -8227,20 +8227,20 @@ exports[`Icon all icons 166`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -8276,20 +8276,20 @@ exports[`Icon all icons 167`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -8325,20 +8325,20 @@ exports[`Icon all icons 168`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -8374,20 +8374,20 @@ exports[`Icon all icons 169`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -8423,20 +8423,20 @@ exports[`Icon all icons 170`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -8472,20 +8472,20 @@ exports[`Icon all icons 171`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -8521,20 +8521,20 @@ exports[`Icon all icons 172`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -8570,20 +8570,20 @@ exports[`Icon all icons 173`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -8619,20 +8619,20 @@ exports[`Icon all icons 174`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -8668,20 +8668,20 @@ exports[`Icon all icons 175`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -8717,20 +8717,20 @@ exports[`Icon all icons 176`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -8766,20 +8766,20 @@ exports[`Icon all icons 177`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -8815,20 +8815,20 @@ exports[`Icon all icons 178`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -8864,20 +8864,20 @@ exports[`Icon all icons 179`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -8913,20 +8913,20 @@ exports[`Icon all icons 180`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -8962,20 +8962,20 @@ exports[`Icon all icons 181`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -9011,20 +9011,20 @@ exports[`Icon all icons 182`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -9060,20 +9060,20 @@ exports[`Icon all icons 183`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -9109,20 +9109,20 @@ exports[`Icon all icons 184`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -9158,20 +9158,20 @@ exports[`Icon all icons 185`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -9206,20 +9206,20 @@ exports[`Icon all icons 186`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -9255,20 +9255,20 @@ exports[`Icon all icons 187`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -9304,20 +9304,20 @@ exports[`Icon all icons 188`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -9353,20 +9353,20 @@ exports[`Icon all icons 189`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -9402,20 +9402,20 @@ exports[`Icon all icons 190`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -9451,20 +9451,20 @@ exports[`Icon all icons 191`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -9498,20 +9498,20 @@ exports[`Icon all icons 192`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -9547,20 +9547,20 @@ exports[`Icon all icons 193`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -9595,20 +9595,20 @@ exports[`Icon all icons 194`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -9644,20 +9644,20 @@ exports[`Icon all icons 195`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -9691,20 +9691,20 @@ exports[`Icon all icons 196`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -9754,20 +9754,20 @@ exports[`Icon all icons 197`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -9802,20 +9802,20 @@ exports[`Icon all icons 198`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -9851,20 +9851,20 @@ exports[`Icon all icons 199`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -9900,20 +9900,20 @@ exports[`Icon all icons 200`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -9950,20 +9950,20 @@ exports[`Icon all icons 201`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -9997,20 +9997,20 @@ exports[`Icon all icons 202`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -10046,20 +10046,20 @@ exports[`Icon all icons 203`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -10095,20 +10095,20 @@ exports[`Icon all icons 204`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -10144,20 +10144,20 @@ exports[`Icon all icons 205`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -10194,20 +10194,20 @@ exports[`Icon all icons 206`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -10243,20 +10243,20 @@ exports[`Icon all icons 207`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -10302,20 +10302,20 @@ exports[`Icon all icons 208`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -10350,20 +10350,20 @@ exports[`Icon all icons 209`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -10398,20 +10398,20 @@ exports[`Icon all icons 210`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -10474,20 +10474,20 @@ exports[`Icon all icons 211`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -10523,20 +10523,20 @@ exports[`Icon all icons 212`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -10572,20 +10572,20 @@ exports[`Icon all icons 213`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -10621,20 +10621,20 @@ exports[`Icon all icons 214`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -10669,20 +10669,20 @@ exports[`Icon all icons 215`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -10740,20 +10740,20 @@ exports[`Icon all icons 216`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -10789,20 +10789,20 @@ exports[`Icon all icons 217`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -10839,20 +10839,20 @@ exports[`Icon all icons 218`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -10888,20 +10888,20 @@ exports[`Icon all icons 219`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -10936,20 +10936,20 @@ exports[`Icon all icons 220`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -10985,20 +10985,20 @@ exports[`Icon all icons 221`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -11034,20 +11034,20 @@ exports[`Icon all icons 222`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -11083,20 +11083,20 @@ exports[`Icon all icons 223`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -11132,20 +11132,20 @@ exports[`Icon all icons 224`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -11181,20 +11181,20 @@ exports[`Icon all icons 225`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -11230,20 +11230,20 @@ exports[`Icon all icons 226`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -11279,20 +11279,20 @@ exports[`Icon all icons 227`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -11328,20 +11328,20 @@ exports[`Icon all icons 228`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -11377,20 +11377,20 @@ exports[`Icon all icons 229`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -11426,20 +11426,20 @@ exports[`Icon all icons 230`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -11475,20 +11475,20 @@ exports[`Icon all icons 231`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -11524,20 +11524,20 @@ exports[`Icon all icons 232`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -11573,20 +11573,20 @@ exports[`Icon all icons 233`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -11622,20 +11622,20 @@ exports[`Icon all icons 234`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -11671,20 +11671,20 @@ exports[`Icon all icons 235`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -11720,20 +11720,20 @@ exports[`Icon all icons 236`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -11769,20 +11769,20 @@ exports[`Icon all icons 237`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -11818,20 +11818,20 @@ exports[`Icon all icons 238`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -11867,20 +11867,20 @@ exports[`Icon all icons 239`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -11916,20 +11916,20 @@ exports[`Icon all icons 240`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -11965,20 +11965,20 @@ exports[`Icon all icons 241`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -12014,20 +12014,20 @@ exports[`Icon all icons 242`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -12063,20 +12063,20 @@ exports[`Icon all icons 243`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -12112,20 +12112,20 @@ exports[`Icon all icons 244`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -12161,20 +12161,20 @@ exports[`Icon all icons 245`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -12210,20 +12210,20 @@ exports[`Icon all icons 246`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -12259,20 +12259,20 @@ exports[`Icon all icons 247`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -12308,20 +12308,20 @@ exports[`Icon all icons 248`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -12357,20 +12357,20 @@ exports[`Icon all icons 249`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -12406,20 +12406,20 @@ exports[`Icon all icons 250`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -12455,20 +12455,20 @@ exports[`Icon all icons 251`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -12504,20 +12504,20 @@ exports[`Icon all icons 252`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -12553,20 +12553,20 @@ exports[`Icon all icons 253`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -12602,20 +12602,20 @@ exports[`Icon all icons 254`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -12651,20 +12651,20 @@ exports[`Icon all icons 255`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -12699,20 +12699,20 @@ exports[`Icon all icons 256`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -12748,20 +12748,20 @@ exports[`Icon all icons 257`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -12797,20 +12797,20 @@ exports[`Icon all icons 258`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -12846,20 +12846,20 @@ exports[`Icon all icons 259`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -12893,20 +12893,20 @@ exports[`Icon all icons 260`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -12942,20 +12942,20 @@ exports[`Icon all icons 261`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -12991,20 +12991,20 @@ exports[`Icon all icons 262`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -13039,20 +13039,20 @@ exports[`Icon all icons 263`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -13088,20 +13088,20 @@ exports[`Icon all icons 264`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -13147,20 +13147,20 @@ exports[`Icon all icons 265`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -13203,20 +13203,20 @@ exports[`Icon all icons 266`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -13251,20 +13251,20 @@ exports[`Icon all icons 267`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -13299,20 +13299,20 @@ exports[`Icon all icons 268`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -13358,20 +13358,20 @@ exports[`Icon all icons 269`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -13405,20 +13405,20 @@ exports[`Icon all icons 270`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -13454,20 +13454,20 @@ exports[`Icon all icons 271`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -13503,20 +13503,20 @@ exports[`Icon all icons 272`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -13552,20 +13552,20 @@ exports[`Icon all icons 273`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -13601,20 +13601,20 @@ exports[`Icon all icons 274`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -13650,20 +13650,20 @@ exports[`Icon all icons 275`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -13698,20 +13698,20 @@ exports[`Icon all icons 276`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -13747,20 +13747,20 @@ exports[`Icon all icons 277`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -13796,20 +13796,20 @@ exports[`Icon all icons 278`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -13845,20 +13845,20 @@ exports[`Icon all icons 279`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -13893,20 +13893,20 @@ exports[`Icon all icons 280`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -13942,20 +13942,20 @@ exports[`Icon all icons 281`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -13991,20 +13991,20 @@ exports[`Icon all icons 282`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -14044,20 +14044,20 @@ exports[`Icon all icons 283`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -14093,20 +14093,20 @@ exports[`Icon all icons 284`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -14142,20 +14142,20 @@ exports[`Icon all icons 285`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -14190,20 +14190,20 @@ exports[`Icon all icons 286`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -14239,20 +14239,20 @@ exports[`Icon all icons 287`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -14288,20 +14288,20 @@ exports[`Icon all icons 288`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -14336,20 +14336,20 @@ exports[`Icon all icons 289`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -14385,20 +14385,20 @@ exports[`Icon all icons 290`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -14434,20 +14434,20 @@ exports[`Icon all icons 291`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -14482,20 +14482,20 @@ exports[`Icon all icons 292`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -14531,20 +14531,20 @@ exports[`Icon all icons 293`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -14580,20 +14580,20 @@ exports[`Icon all icons 294`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -14629,20 +14629,20 @@ exports[`Icon all icons 295`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -14678,20 +14678,20 @@ exports[`Icon all icons 296`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -14727,20 +14727,20 @@ exports[`Icon all icons 297`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -14776,20 +14776,20 @@ exports[`Icon all icons 298`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -14825,20 +14825,20 @@ exports[`Icon all icons 299`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -14874,20 +14874,20 @@ exports[`Icon all icons 300`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -14923,20 +14923,20 @@ exports[`Icon all icons 301`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -14972,20 +14972,20 @@ exports[`Icon all icons 302`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -15021,20 +15021,20 @@ exports[`Icon all icons 303`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -15067,20 +15067,20 @@ exports[`Icon all icons 304`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -15116,20 +15116,20 @@ exports[`Icon all icons 305`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -15165,20 +15165,20 @@ exports[`Icon all icons 306`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -15214,20 +15214,20 @@ exports[`Icon all icons 307`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -15262,20 +15262,20 @@ exports[`Icon all icons 308`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -15308,20 +15308,20 @@ exports[`Icon all icons 309`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -15357,20 +15357,20 @@ exports[`Icon all icons 310`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -15406,20 +15406,20 @@ exports[`Icon all icons 311`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -15463,20 +15463,20 @@ exports[`Icon all icons 312`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -15512,20 +15512,20 @@ exports[`Icon all icons 313`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -15561,20 +15561,20 @@ exports[`Icon all icons 314`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -15610,20 +15610,20 @@ exports[`Icon all icons 315`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -15657,20 +15657,20 @@ exports[`Icon all icons 316`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -15706,20 +15706,20 @@ exports[`Icon all icons 317`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -15755,20 +15755,20 @@ exports[`Icon all icons 318`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -15804,20 +15804,20 @@ exports[`Icon all icons 319`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -15853,20 +15853,20 @@ exports[`Icon all icons 320`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -15903,20 +15903,20 @@ exports[`Icon all icons 321`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -15952,20 +15952,20 @@ exports[`Icon all icons 322`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -16001,20 +16001,20 @@ exports[`Icon all icons 323`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -16050,20 +16050,20 @@ exports[`Icon all icons 324`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -16099,20 +16099,20 @@ exports[`Icon all icons 325`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -16148,20 +16148,20 @@ exports[`Icon all icons 326`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -16197,20 +16197,20 @@ exports[`Icon all icons 327`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -16246,20 +16246,20 @@ exports[`Icon all icons 328`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -16295,20 +16295,20 @@ exports[`Icon all icons 329`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -16343,20 +16343,20 @@ exports[`Icon all icons 330`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -16391,20 +16391,20 @@ exports[`Icon all icons 331`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -16441,20 +16441,20 @@ exports[`Icon all icons 332`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -16490,20 +16490,20 @@ exports[`Icon all icons 333`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -16539,20 +16539,20 @@ exports[`Icon all icons 334`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -16588,20 +16588,20 @@ exports[`Icon all icons 335`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -16637,20 +16637,20 @@ exports[`Icon all icons 336`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -16686,20 +16686,20 @@ exports[`Icon all icons 337`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -16735,20 +16735,20 @@ exports[`Icon all icons 338`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -16784,20 +16784,20 @@ exports[`Icon all icons 339`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -16833,20 +16833,20 @@ exports[`Icon all icons 340`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -16882,20 +16882,20 @@ exports[`Icon all icons 341`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -16930,20 +16930,20 @@ exports[`Icon all icons 342`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -16978,20 +16978,20 @@ exports[`Icon all icons 343`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -17027,20 +17027,20 @@ exports[`Icon all icons 344`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -17076,20 +17076,20 @@ exports[`Icon all icons 345`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -17125,20 +17125,20 @@ exports[`Icon all icons 346`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -17186,20 +17186,20 @@ exports[`Icon all icons 347`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -17233,20 +17233,20 @@ exports[`Icon all icons 348`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -17282,20 +17282,20 @@ exports[`Icon all icons 349`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -17331,20 +17331,20 @@ exports[`Icon all icons 350`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -17379,20 +17379,20 @@ exports[`Icon all icons 351`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -17428,20 +17428,20 @@ exports[`Icon all icons 352`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -17477,20 +17477,20 @@ exports[`Icon all icons 353`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -17526,20 +17526,20 @@ exports[`Icon all icons 354`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -17572,20 +17572,20 @@ exports[`Icon all icons 355`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -17622,20 +17622,20 @@ exports[`Icon all icons 356`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -17668,20 +17668,20 @@ exports[`Icon all icons 357`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -17717,20 +17717,20 @@ exports[`Icon all icons 358`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -17766,20 +17766,20 @@ exports[`Icon all icons 359`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -17817,20 +17817,20 @@ exports[`Icon all icons 360`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -17866,20 +17866,20 @@ exports[`Icon all icons 361`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -17915,20 +17915,20 @@ exports[`Icon all icons 362`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -17963,20 +17963,20 @@ exports[`Icon all icons 363`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -18012,20 +18012,20 @@ exports[`Icon all icons 364`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -18061,20 +18061,20 @@ exports[`Icon all icons 365`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -18110,20 +18110,20 @@ exports[`Icon all icons 366`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -18159,20 +18159,20 @@ exports[`Icon all icons 367`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -18208,20 +18208,20 @@ exports[`Icon all icons 368`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -18257,20 +18257,20 @@ exports[`Icon all icons 369`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -18304,20 +18304,20 @@ exports[`Icon all icons 370`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -18353,20 +18353,20 @@ exports[`Icon all icons 371`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -18400,20 +18400,20 @@ exports[`Icon all icons 372`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -18449,20 +18449,20 @@ exports[`Icon all icons 373`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -18498,20 +18498,20 @@ exports[`Icon all icons 374`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -18547,20 +18547,20 @@ exports[`Icon all icons 375`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -18603,20 +18603,20 @@ exports[`Icon all icons 376`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -18652,20 +18652,20 @@ exports[`Icon all icons 377`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -18701,20 +18701,20 @@ exports[`Icon all icons 378`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -18750,20 +18750,20 @@ exports[`Icon all icons 379`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -18798,20 +18798,20 @@ exports[`Icon all icons 380`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -18846,20 +18846,20 @@ exports[`Icon all icons 381`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -18895,20 +18895,20 @@ exports[`Icon all icons 382`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -18943,20 +18943,20 @@ exports[`Icon all icons 383`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -18989,20 +18989,20 @@ exports[`Icon all icons 384`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -19038,20 +19038,20 @@ exports[`Icon all icons 385`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -19087,20 +19087,20 @@ exports[`Icon all icons 386`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -19136,20 +19136,20 @@ exports[`Icon all icons 387`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -19185,20 +19185,20 @@ exports[`Icon all icons 388`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -19234,20 +19234,20 @@ exports[`Icon all icons 389`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -19283,20 +19283,20 @@ exports[`Icon all icons 390`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -19332,20 +19332,20 @@ exports[`Icon all icons 391`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -19380,20 +19380,20 @@ exports[`Icon all icons 392`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -19431,20 +19431,20 @@ exports[`Icon all icons 393`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -19480,20 +19480,20 @@ exports[`Icon all icons 394`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -19529,20 +19529,20 @@ exports[`Icon all icons 395`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -19578,20 +19578,20 @@ exports[`Icon all icons 396`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -19627,20 +19627,20 @@ exports[`Icon all icons 397`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -19676,20 +19676,20 @@ exports[`Icon all icons 398`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -19725,20 +19725,20 @@ exports[`Icon all icons 399`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -19773,20 +19773,20 @@ exports[`Icon all icons 400`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -19822,20 +19822,20 @@ exports[`Icon all icons 401`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -19870,20 +19870,20 @@ exports[`Icon all icons 402`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -19919,20 +19919,20 @@ exports[`Icon all icons 403`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -19968,20 +19968,20 @@ exports[`Icon all icons 404`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -20017,20 +20017,20 @@ exports[`Icon all icons 405`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -20066,20 +20066,20 @@ exports[`Icon all icons 406`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -20125,20 +20125,20 @@ exports[`Icon all icons 407`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -20174,20 +20174,20 @@ exports[`Icon all icons 408`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -20223,20 +20223,20 @@ exports[`Icon all icons 409`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -20272,20 +20272,20 @@ exports[`Icon all icons 410`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -20321,20 +20321,20 @@ exports[`Icon all icons 411`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -20370,20 +20370,20 @@ exports[`Icon all icons 412`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -20419,20 +20419,20 @@ exports[`Icon all icons 413`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -20468,20 +20468,20 @@ exports[`Icon all icons 414`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -20516,20 +20516,20 @@ exports[`Icon all icons 415`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -20565,20 +20565,20 @@ exports[`Icon all icons 416`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -20622,20 +20622,20 @@ exports[`Icon all icons 417`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -20671,20 +20671,20 @@ exports[`Icon all icons 418`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -20722,20 +20722,20 @@ exports[`Icon all icons 419`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -20770,20 +20770,20 @@ exports[`Icon all icons 420`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -20827,20 +20827,20 @@ exports[`Icon all icons 421`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -20875,20 +20875,20 @@ exports[`Icon all icons 422`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -20931,20 +20931,20 @@ exports[`Icon all icons 423`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -20977,20 +20977,20 @@ exports[`Icon all icons 424`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -21026,20 +21026,20 @@ exports[`Icon all icons 425`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -21075,20 +21075,20 @@ exports[`Icon all icons 426`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -21124,20 +21124,20 @@ exports[`Icon all icons 427`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -21175,20 +21175,20 @@ exports[`Icon all icons 428`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -21226,20 +21226,20 @@ exports[`Icon all icons 429`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -21276,20 +21276,20 @@ exports[`Icon all icons 430`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -21325,20 +21325,20 @@ exports[`Icon all icons 431`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -21374,20 +21374,20 @@ exports[`Icon all icons 432`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -21423,20 +21423,20 @@ exports[`Icon all icons 433`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -21472,20 +21472,20 @@ exports[`Icon all icons 434`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -21521,20 +21521,20 @@ exports[`Icon all icons 435`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -21570,20 +21570,20 @@ exports[`Icon all icons 436`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -21616,20 +21616,20 @@ exports[`Icon all icons 437`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -21662,20 +21662,20 @@ exports[`Icon all icons 438`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -21711,20 +21711,20 @@ exports[`Icon all icons 439`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -21762,20 +21762,20 @@ exports[`Icon all icons 440`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -21810,20 +21810,20 @@ exports[`Icon all icons 441`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -21859,20 +21859,20 @@ exports[`Icon all icons 442`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -21908,20 +21908,20 @@ exports[`Icon all icons 443`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -21957,20 +21957,20 @@ exports[`Icon all icons 444`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -22006,20 +22006,20 @@ exports[`Icon all icons 445`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -22055,20 +22055,20 @@ exports[`Icon all icons 446`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -22104,20 +22104,20 @@ exports[`Icon all icons 447`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -22153,20 +22153,20 @@ exports[`Icon all icons 448`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -22202,20 +22202,20 @@ exports[`Icon all icons 449`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -22250,20 +22250,20 @@ exports[`Icon all icons 450`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -22299,20 +22299,20 @@ exports[`Icon all icons 451`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -22348,20 +22348,20 @@ exports[`Icon all icons 452`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -22397,20 +22397,20 @@ exports[`Icon all icons 453`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -22446,20 +22446,20 @@ exports[`Icon all icons 454`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -22495,20 +22495,20 @@ exports[`Icon all icons 455`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -22544,20 +22544,20 @@ exports[`Icon all icons 456`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -22593,20 +22593,20 @@ exports[`Icon all icons 457`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -22642,20 +22642,20 @@ exports[`Icon all icons 458`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -22691,20 +22691,20 @@ exports[`Icon all icons 459`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -22740,20 +22740,20 @@ exports[`Icon all icons 460`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -22789,20 +22789,20 @@ exports[`Icon all icons 461`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -22838,20 +22838,20 @@ exports[`Icon all icons 462`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -22887,20 +22887,20 @@ exports[`Icon all icons 463`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -22936,20 +22936,20 @@ exports[`Icon all icons 464`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -22985,20 +22985,20 @@ exports[`Icon all icons 465`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -23034,20 +23034,20 @@ exports[`Icon all icons 466`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -23083,20 +23083,20 @@ exports[`Icon all icons 467`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -23132,20 +23132,20 @@ exports[`Icon all icons 468`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -23181,20 +23181,20 @@ exports[`Icon all icons 469`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -23230,20 +23230,20 @@ exports[`Icon all icons 470`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -23279,20 +23279,20 @@ exports[`Icon all icons 471`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -23328,20 +23328,20 @@ exports[`Icon all icons 472`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -23378,20 +23378,20 @@ exports[`Icon all icons 473`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -23427,20 +23427,20 @@ exports[`Icon all icons 474`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -23476,20 +23476,20 @@ exports[`Icon all icons 475`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -23524,20 +23524,20 @@ exports[`Icon all icons 476`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -23588,20 +23588,20 @@ exports[`Icon all icons 477`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -23636,20 +23636,20 @@ exports[`Icon all icons 478`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -23684,20 +23684,20 @@ exports[`Icon all icons 479`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -23733,20 +23733,20 @@ exports[`Icon all icons 480`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -23781,20 +23781,20 @@ exports[`Icon all icons 481`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -23830,20 +23830,20 @@ exports[`Icon all icons 482`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -23878,20 +23878,20 @@ exports[`Icon all icons 483`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -23927,20 +23927,20 @@ exports[`Icon all icons 484`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -23976,20 +23976,20 @@ exports[`Icon all icons 485`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -24024,20 +24024,20 @@ exports[`Icon all icons 486`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -24072,20 +24072,20 @@ exports[`Icon all icons 487`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -24120,20 +24120,20 @@ exports[`Icon all icons 488`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -24169,20 +24169,20 @@ exports[`Icon all icons 489`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -24226,20 +24226,20 @@ exports[`Icon all icons 490`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -24274,20 +24274,20 @@ exports[`Icon all icons 491`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -24323,20 +24323,20 @@ exports[`Icon all icons 492`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -24371,20 +24371,20 @@ exports[`Icon all icons 493`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -24420,20 +24420,20 @@ exports[`Icon all icons 494`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -24472,20 +24472,20 @@ exports[`Icon all icons 495`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -24521,20 +24521,20 @@ exports[`Icon all icons 496`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -24571,20 +24571,20 @@ exports[`Icon all icons 497`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -24620,20 +24620,20 @@ exports[`Icon all icons 498`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -24672,20 +24672,20 @@ exports[`Icon all icons 499`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -24721,20 +24721,20 @@ exports[`Icon all icons 500`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -24773,20 +24773,20 @@ exports[`Icon all icons 501`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -24826,20 +24826,20 @@ exports[`Icon all icons 502`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -24878,20 +24878,20 @@ exports[`Icon all icons 503`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -24927,20 +24927,20 @@ exports[`Icon all icons 504`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -24976,20 +24976,20 @@ exports[`Icon all icons 505`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -25026,20 +25026,20 @@ exports[`Icon all icons 506`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -25075,20 +25075,20 @@ exports[`Icon all icons 507`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -25124,20 +25124,20 @@ exports[`Icon all icons 508`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -25173,20 +25173,20 @@ exports[`Icon all icons 509`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -25222,20 +25222,20 @@ exports[`Icon all icons 510`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -25271,20 +25271,20 @@ exports[`Icon all icons 511`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -25320,20 +25320,20 @@ exports[`Icon all icons 512`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -25366,20 +25366,20 @@ exports[`Icon all icons 513`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -25414,20 +25414,20 @@ exports[`Icon all icons 514`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -25460,20 +25460,20 @@ exports[`Icon all icons 515`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -25509,20 +25509,20 @@ exports[`Icon all icons 516`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -25558,20 +25558,20 @@ exports[`Icon all icons 517`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -25609,20 +25609,20 @@ exports[`Icon all icons 518`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -25655,20 +25655,20 @@ exports[`Icon all icons 519`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -25704,20 +25704,20 @@ exports[`Icon all icons 520`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -25752,20 +25752,20 @@ exports[`Icon all icons 521`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -25800,20 +25800,20 @@ exports[`Icon all icons 522`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -25851,20 +25851,20 @@ exports[`Icon all icons 523`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -25900,20 +25900,20 @@ exports[`Icon all icons 524`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -25949,20 +25949,20 @@ exports[`Icon all icons 525`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -25998,20 +25998,20 @@ exports[`Icon all icons 526`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -26047,20 +26047,20 @@ exports[`Icon all icons 527`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -26096,20 +26096,20 @@ exports[`Icon all icons 528`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -26145,20 +26145,20 @@ exports[`Icon all icons 529`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -26194,20 +26194,20 @@ exports[`Icon all icons 530`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -26243,20 +26243,20 @@ exports[`Icon all icons 531`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -26292,20 +26292,20 @@ exports[`Icon all icons 532`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -26341,20 +26341,20 @@ exports[`Icon all icons 533`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -26390,20 +26390,20 @@ exports[`Icon all icons 534`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -26441,20 +26441,20 @@ exports[`Icon all icons 535`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -26490,20 +26490,20 @@ exports[`Icon all icons 536`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -26539,20 +26539,20 @@ exports[`Icon all icons 537`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -26588,20 +26588,20 @@ exports[`Icon all icons 538`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -26637,20 +26637,20 @@ exports[`Icon all icons 539`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -26683,20 +26683,20 @@ exports[`Icon all icons 540`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -26729,20 +26729,20 @@ exports[`Icon all icons 541`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -26775,20 +26775,20 @@ exports[`Icon all icons 542`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -26821,20 +26821,20 @@ exports[`Icon all icons 543`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -26870,20 +26870,20 @@ exports[`Icon all icons 544`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -26919,20 +26919,20 @@ exports[`Icon all icons 545`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -26968,20 +26968,20 @@ exports[`Icon all icons 546`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -27017,20 +27017,20 @@ exports[`Icon all icons 547`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -27066,20 +27066,20 @@ exports[`Icon all icons 548`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -27131,20 +27131,20 @@ exports[`Icon all icons 549`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -27180,20 +27180,20 @@ exports[`Icon all icons 550`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -27229,20 +27229,20 @@ exports[`Icon all icons 551`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -27278,20 +27278,20 @@ exports[`Icon all icons 552`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -27327,20 +27327,20 @@ exports[`Icon all icons 553`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -27376,20 +27376,20 @@ exports[`Icon all icons 554`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -27425,20 +27425,20 @@ exports[`Icon all icons 555`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -27474,20 +27474,20 @@ exports[`Icon all icons 556`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -27523,20 +27523,20 @@ exports[`Icon all icons 557`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -27572,20 +27572,20 @@ exports[`Icon all icons 558`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -27621,20 +27621,20 @@ exports[`Icon all icons 559`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -27670,20 +27670,20 @@ exports[`Icon all icons 560`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -27719,20 +27719,20 @@ exports[`Icon all icons 561`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -27768,20 +27768,20 @@ exports[`Icon all icons 562`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -27817,20 +27817,20 @@ exports[`Icon all icons 563`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -27867,20 +27867,20 @@ exports[`Icon all icons 564`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -27915,20 +27915,20 @@ exports[`Icon all icons 565`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -27963,20 +27963,20 @@ exports[`Icon all icons 566`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -28011,20 +28011,20 @@ exports[`Icon all icons 567`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -28059,20 +28059,20 @@ exports[`Icon all icons 568`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -28105,20 +28105,20 @@ exports[`Icon all icons 569`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -28151,20 +28151,20 @@ exports[`Icon all icons 570`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -28200,20 +28200,20 @@ exports[`Icon all icons 571`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -28249,20 +28249,20 @@ exports[`Icon all icons 572`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -28310,20 +28310,20 @@ exports[`Icon all icons 573`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -28359,20 +28359,20 @@ exports[`Icon all icons 574`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -28408,20 +28408,20 @@ exports[`Icon all icons 575`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -28457,20 +28457,20 @@ exports[`Icon all icons 576`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -28506,20 +28506,20 @@ exports[`Icon all icons 577`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -28555,20 +28555,20 @@ exports[`Icon all icons 578`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -28604,20 +28604,20 @@ exports[`Icon all icons 579`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -28653,20 +28653,20 @@ exports[`Icon all icons 580`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -28702,20 +28702,20 @@ exports[`Icon all icons 581`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -28751,20 +28751,20 @@ exports[`Icon all icons 582`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -28800,20 +28800,20 @@ exports[`Icon all icons 583`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -28849,20 +28849,20 @@ exports[`Icon all icons 584`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -28898,20 +28898,20 @@ exports[`Icon all icons 585`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -28947,20 +28947,20 @@ exports[`Icon all icons 586`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -28996,20 +28996,20 @@ exports[`Icon all icons 587`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -29045,20 +29045,20 @@ exports[`Icon all icons 588`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -29094,20 +29094,20 @@ exports[`Icon all icons 589`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -29143,20 +29143,20 @@ exports[`Icon all icons 590`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -29192,20 +29192,20 @@ exports[`Icon all icons 591`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -29241,20 +29241,20 @@ exports[`Icon all icons 592`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -29290,20 +29290,20 @@ exports[`Icon all icons 593`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -29339,20 +29339,20 @@ exports[`Icon all icons 594`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -29387,20 +29387,20 @@ exports[`Icon all icons 595`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -29436,20 +29436,20 @@ exports[`Icon all icons 596`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -29485,20 +29485,20 @@ exports[`Icon all icons 597`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -29533,20 +29533,20 @@ exports[`Icon all icons 598`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -29582,20 +29582,20 @@ exports[`Icon all icons 599`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -29630,20 +29630,20 @@ exports[`Icon all icons 600`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -29679,20 +29679,20 @@ exports[`Icon all icons 601`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -29728,20 +29728,20 @@ exports[`Icon all icons 602`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -29777,20 +29777,20 @@ exports[`Icon all icons 603`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -29826,20 +29826,20 @@ exports[`Icon all icons 604`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -29875,20 +29875,20 @@ exports[`Icon all icons 605`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -29924,20 +29924,20 @@ exports[`Icon all icons 606`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -30008,20 +30008,20 @@ exports[`Icon all icons 607`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -30059,20 +30059,20 @@ exports[`Icon all icons 608`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -30110,20 +30110,20 @@ exports[`Icon all icons 609`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -30168,20 +30168,20 @@ exports[`Icon all icons 610`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -30225,20 +30225,20 @@ exports[`Icon all icons 611`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -30284,20 +30284,20 @@ exports[`Icon all icons 612`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -30333,20 +30333,20 @@ exports[`Icon all icons 613`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -30397,20 +30397,20 @@ exports[`Icon all icons 614`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -30445,20 +30445,20 @@ exports[`Icon all icons 615`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -30493,20 +30493,20 @@ exports[`Icon all icons 616`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -30542,20 +30542,20 @@ exports[`Icon all icons 617`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -30593,20 +30593,20 @@ exports[`Icon all icons 618`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -30641,20 +30641,20 @@ exports[`Icon all icons 619`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -30690,20 +30690,20 @@ exports[`Icon all icons 620`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -30739,20 +30739,20 @@ exports[`Icon all icons 621`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -30790,20 +30790,20 @@ exports[`Icon all icons 622`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -30832,20 +30832,20 @@ exports[`Icon basic 1`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -30887,20 +30887,20 @@ exports[`Icon custom pixel size 1`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -30942,20 +30942,20 @@ exports[`Icon large 1`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -30997,20 +30997,20 @@ exports[`Icon title 1`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -31053,20 +31053,20 @@ exports[`Icon xlarge 1`] = `
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c0 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c0 *[stroke*='#'],
+.c0 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
 .c0 *[fill-rule],
 .c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c0 *[fill*='#'],
+.c0 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6536,11 +6536,6 @@ grapheme-splitter@^1.0.4:
   resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
   integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
 
-grommet-styles@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/grommet-styles/-/grommet-styles-0.2.0.tgz#b2eac2b7e2747cb523434d21728ce5234f8ce4f4"
-  integrity sha512-0OMSYuGeyifYKpg4Gv2HzL8rUdd0ddnJ5LbCBKgDuloC71XIwr9g/Fxa6rs737MbPV7OZ4pEm4wvrjH4epzf1A==
-
 handlebars@^4.7.7:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"


### PR DESCRIPTION
Removes dependency on grommet-styles package.

The snapshot changes are coming from a lint change (see StyledIcon.js line 62 for example)