### PR TITLE
Add use client to grommet-icons

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,3 +1,5 @@
+'use client';
+
 export * from './default-props';
 export * from './icons';
 export * from './themes';


### PR DESCRIPTION
For NextJS app router, adding `use client` to export.